### PR TITLE
fix: use Symbol.for() for EMBER_OWNER_KEY to fix production build

### DIFF
--- a/vite-plugin-ember/src/vitepress/constants.ts
+++ b/vite-plugin-ember/src/vitepress/constants.ts
@@ -2,5 +2,8 @@
  * Vue injection key for providing a default Ember owner to all CodePreview
  * instances. You typically don't need this directly — use `setupEmber()`
  * from `vite-plugin-ember/setup` instead.
+ *
+ * Uses `Symbol.for()` so the key is identical across module boundaries
+ * (e.g. dist/ vs src/ paths that Vite may load separately).
  */
-export const EMBER_OWNER_KEY = Symbol('ember-owner');
+export const EMBER_OWNER_KEY = Symbol.for('vite-plugin-ember:owner');


### PR DESCRIPTION
In production, Vite loads constants.ts from two different paths (dist/vitepress/constants.js via setup.ts and src/vitepress/constants.ts via code-preview.vue). Symbol() creates unique values per call, so the provide/inject keys didn't match — the owner was never injected and @service failed with 'i.lookup is not a function'.

Symbol.for() uses a global registry, guaranteeing the same Symbol instance regardless of which module path creates it.