### PR TITLE
feat: make collapsible code preview opt-in via flag

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -30,7 +30,7 @@ The simplest live demo — a `<template>` tag with no class:
 
 ## Live + Preview
 
-Adding `preview` shows the rendered output with a collapsible source code panel:
+Adding `preview` shows both the rendered output and the source code:
 
 ```gjs live preview
 <template>

--- a/docs/guide/plugin-api.md
+++ b/docs/guide/plugin-api.md
@@ -138,17 +138,18 @@ The Vue wrapper component that mounts Ember components into the page.
 
 ### Props
 
-| Prop     | Type                 | Description                                                                          |
-| -------- | -------------------- | ------------------------------------------------------------------------------------ |
-| `loader` | `() => Promise<any>` | A function that returns a dynamic import of the Ember module (preferred)             |
-| `src`    | `string`             | URL of the module to import (fallback, uses `@vite-ignore`)                          |
-| `owner`  | `object`             | An Ember owner for dependency injection (`@service`). Overrides the injected default |
+| Prop          | Type                 | Description                                                                          |
+| ------------- | -------------------- | ------------------------------------------------------------------------------------ |
+| `loader`      | `() => Promise<any>` | A function that returns a dynamic import of the Ember module (preferred)             |
+| `src`         | `string`             | URL of the module to import (fallback, uses `@vite-ignore`)                          |
+| `owner`       | `object`             | An Ember owner for dependency injection (`@service`). Overrides the injected default |
+| `collapsible` | `boolean`            | Wrap the source code in a collapsible "Show code" toggle (default: `false`)          |
 
 ### Slots
 
-| Slot      | Description                                                                                                        |
-| --------- | ------------------------------------------------------------------------------------------------------------------ |
-| `default` | Content displayed in a collapsible panel below the rendered component (used by `preview` mode to show source code) |
+| Slot      | Description                                                                                                                                     |
+| --------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| `default` | Content displayed below the rendered component (used by `preview` mode to show source code). Add the `collapsible` prop to wrap it in a toggle. |
 
 ### How it works
 

--- a/docs/guide/writing-components.md
+++ b/docs/guide/writing-components.md
@@ -109,17 +109,19 @@ The plugin automatically strips type annotations via `@babel/plugin-transform-ty
 
 ## Code fence flags
 
-| Syntax                  | Behavior                                               |
-| ----------------------- | ------------------------------------------------------ |
-| ` ```gjs `              | Static, syntax-highlighted code only                   |
-| ` ```gjs live `         | Live rendered component                                |
-| ` ```gjs live preview ` | Live component with collapsible source code            |
-| ` ```gts live `         | Live TypeScript component                              |
-| ` ```gts live preview ` | Live TypeScript component with collapsible source code |
+| Syntax                              | Behavior                                               |
+| ----------------------------------- | ------------------------------------------------------ |
+| ` ```gjs `                          | Static, syntax-highlighted code only                   |
+| ` ```gjs live `                     | Live rendered component                                |
+| ` ```gjs live preview `             | Live component with source code displayed below        |
+| ` ```gjs live preview collapsible ` | Live component with collapsible source code            |
+| ` ```gts live `                     | Live TypeScript component                              |
+| ` ```gts live preview `             | Live TypeScript component with source code             |
+| ` ```gts live preview collapsible ` | Live TypeScript component with collapsible source code |
 
 ### Preview mode
 
-Adding `preview` shows the rendered output with a collapsible "Show code" toggle below it:
+Adding `preview` shows both the rendered output and the source code:
 
 ```gjs live preview
 <template>

--- a/docs/index.md
+++ b/docs/index.md
@@ -25,5 +25,5 @@ features:
     details: The plugin handles content-tag preprocessing, Babel template compilation, decorator transforms, and module resolution automatically.
   - icon: 👁️
     title: Preview mode
-    details: Add the preview flag to show the rendered component with a collapsible source code panel — great for API docs and tutorials.
+    details: Add the preview flag to show the rendered component alongside its syntax-highlighted source code. Use collapsible to hide the code behind a toggle.
 ---

--- a/vite-plugin-ember/README.md
+++ b/vite-plugin-ember/README.md
@@ -12,7 +12,7 @@ Write `.gjs` / `.gts` code fences in markdown and see them rendered on the page 
 ## Features
 
 - **Inline code fences** — use ` ```gjs live ` in markdown for instant interactive previews
-- **Preview mode** — add `preview` to show a collapsible source code panel alongside the rendered component
+- **Preview mode** — add `preview` to show source code alongside the rendered component, or `collapsible` to hide it behind a toggle
 - **Full Ember support** — class components, `@tracked` state, `{{on}}` modifier, and TypeScript via `.gts`
 - **Zero-config compilation** — content-tag preprocessing, Babel template compilation, decorator transforms, and `@ember/*` / `@glimmer/*` module resolution handled automatically
 - **`@embroider/macros` shim** — runtime stubs so `ember-source` ESM imports just work

--- a/vite-plugin-ember/src/vitepress/code-preview.vue
+++ b/vite-plugin-ember/src/vitepress/code-preview.vue
@@ -12,6 +12,7 @@ const props = defineProps<{
   loader?: () => Promise<any>;
   owner?: object;
   preview?: boolean;
+  collapsible?: boolean;
 }>();
 const injectedOwner = inject<object | undefined>(EMBER_OWNER_KEY, undefined);
 const mountEl = ref<HTMLDivElement | null>(null);
@@ -57,10 +58,16 @@ onBeforeUnmount(() => {
   <div class="ember-playground">
     <div v-if="error" class="ember-playground__error">{{ error }}</div>
     <div ref="mountEl"></div>
-    <details v-if="$slots.default" class="ember-playground__source">
+    <details
+      v-if="$slots.default && collapsible"
+      class="ember-playground__source"
+    >
       <summary>Show code</summary>
       <slot />
     </details>
+    <div v-else-if="$slots.default" class="ember-playground__source">
+      <slot />
+    </div>
   </div>
 </template>
 

--- a/vite-plugin-ember/src/vitepress/ember-fence.ts
+++ b/vite-plugin-ember/src/vitepress/ember-fence.ts
@@ -82,7 +82,8 @@ export function emberFence(md: MarkdownIt, component = 'CodePreview') {
         token.info = lang;
         const highlighted = originalFence(tokens, idx, options, env, self);
         token.info = savedInfo;
-        return `<${component} :loader="() => import('${virtualId}')">${highlighted}</${component}>`;
+        const collapsible = flags.includes('collapsible') ? ' collapsible' : '';
+        return `<${component} :loader="() => import('${virtualId}')"${collapsible}>${highlighted}</${component}>`;
       }
       return `<${component} :loader="() => import('${virtualId}')" />`;
     }


### PR DESCRIPTION
Preview mode now shows source code directly below the rendered component by default. Add the `collapsible` flag to wrap it in a <details>/<summary> toggle instead.

Code fence: ```gjs live preview collapsible
File-based: <CodePreview src="..." preview collapsible />