### PR TITLE
Support style isolation using the `.vp-raw` class

### DIFF
--- a/vite-plugin-ember/src/vitepress/code-preview.vue
+++ b/vite-plugin-ember/src/vitepress/code-preview.vue
@@ -57,7 +57,7 @@ onBeforeUnmount(() => {
 <template>
   <div class="ember-playground">
     <div v-if="error" class="ember-playground__error">{{ error }}</div>
-    <div ref="mountEl"></div>
+    <div ref="mountEl" class="vp-raw"></div>
     <details
       v-if="$slots.default && collapsible"
       class="ember-playground__source"


### PR DESCRIPTION
See https://vitepress.dev/guide/markdown#raw for more info.
Not sure if just adding this class has any unwanted side effects.
We could also add an option for this since style isolation is also currently opt-in in VitePress?