### PR TITLE
Allow consumers to define styles by default

### DIFF
--- a/vite-plugin-ember/src/vitepress/code-preview.vue
+++ b/vite-plugin-ember/src/vitepress/code-preview.vue
@@ -60,7 +60,7 @@ onBeforeUnmount(() => {
     <div ref="mountEl"></div>
     <details
       v-if="$slots.default && collapsible"
-      class="ember-playground__source"
+      class="ember-playground__show-code"
     >
       <summary>Show code</summary>
       <slot />
@@ -90,12 +90,12 @@ onBeforeUnmount(() => {
   word-break: break-word;
 }
 
-.ember-playground__source {
+.ember-playground__show-code {
   margin-top: 12px;
   border-top: 1px solid var(--vp-c-divider);
 }
 
-.ember-playground__source summary {
+.ember-playground__show-code summary {
   padding: 8px 0 4px;
   cursor: pointer;
   font-size: 13px;
@@ -103,11 +103,11 @@ onBeforeUnmount(() => {
   user-select: none;
 }
 
-.ember-playground__source summary:hover {
+.ember-playground__show-code summary:hover {
   color: var(--vp-c-text-1);
 }
 
-.ember-playground__source :deep(div[class*='language-']) {
+.ember-playground__show-code :deep(div[class*='language-']) {
   margin: 0;
   border-radius: 0 0 8px 8px;
 }

--- a/vite-plugin-ember/src/vitepress/code-preview.vue
+++ b/vite-plugin-ember/src/vitepress/code-preview.vue
@@ -65,7 +65,7 @@ onBeforeUnmount(() => {
       <summary>Show code</summary>
       <slot />
     </details>
-    <div v-else-if="$slots.default" class="ember-playground__source">
+    <div v-else-if="$slots.default">
       <slot />
     </div>
   </div>


### PR DESCRIPTION
## Background

In `0.4.0`, the styles for the `collapsible` case affect those for the default case. As a result, the [docs for `ember-intl`](https://github.com/ember-intl/ember-intl/blob/8.2.5/docs/ember-intl/src/docs/helpers/format-date.md?plain=1#L11-L13) will show a top border when the following code is rendered:

```md
<CodePreview src="/components/locale-switcher.gts">
  <CodePreview src="/snippets/helpers/format-date/example-1/component.gts" />
</CodePreview>
```

<img width="1400" height="800" alt="before" src="https://github.com/user-attachments/assets/fe8d821b-af99-48c0-8812-0442ecc8b83d" />

This pull request, based on [`ember-intl`'s patch](https://github.com/ember-intl/ember-intl/blob/8.2.5/patches/vite-plugin-ember.patch), removes styles for the default case so that consumers can decide for themselves. It also renames the class selector `ember-playground__source` to `ember-playground__show-code`.

<img width="1400" height="800" alt="after" src="https://github.com/user-attachments/assets/f6f13375-086c-46d9-b3a7-8ad93455cfdb" />
