### PR TITLE
fix(vitepress): accept MarkdownItAsync for VitePress v2 compatibility

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -121,6 +121,9 @@ importers:
       markdown-it:
         specifier: ^14.1.1
         version: 14.1.1
+      markdown-it-async:
+        specifier: ^2.2.0
+        version: 2.2.0
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
@@ -3032,6 +3035,9 @@ packages:
 
   mark.js@8.11.1:
     resolution: {integrity: sha512-1I+1qpDt4idfgLQG+BNWmrqku+7/2bi5nLf4YwF8y8zXvmfiTBY3PV3ZibfrjBueCByROpuBjLLFCajqkgYoLQ==}
+
+  markdown-it-async@2.2.0:
+    resolution: {integrity: sha512-sITME+kf799vMeO/ww/CjH6q+c05f6TLpn6VOmmWCGNqPJzSh+uFgZoMB9s0plNtW6afy63qglNAC3MhrhP/gg==}
 
   markdown-it@14.1.1:
     resolution: {integrity: sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==}
@@ -7421,6 +7427,11 @@ snapshots:
       - supports-color
 
   mark.js@8.11.1: {}
+
+  markdown-it-async@2.2.0:
+    dependencies:
+      '@types/markdown-it': 14.1.2
+      markdown-it: 14.1.1
 
   markdown-it@14.1.1:
     dependencies:

--- a/vite-plugin-ember/package.json
+++ b/vite-plugin-ember/package.json
@@ -81,6 +81,7 @@
     "eslint-config-prettier": "^10.1.8",
     "globals": "^17.6.0",
     "markdown-it": "^14.1.1",
+    "markdown-it-async": "^2.2.0",
     "typescript": "^6.0.3",
     "typescript-eslint": "^8.59.3",
     "vite": "^8.0.13",
@@ -91,7 +92,7 @@
     "@glimmer/component": ">=1",
     "ember-source": ">=6.12.0",
     "vite": ">=5",
-    "vitepress": ">=1",
+    "vitepress": ">=1 || >=2.0.0-alpha",
     "vue": ">=3"
   },
   "peerDependenciesMeta": {

--- a/vite-plugin-ember/src/vitepress/code-preview.ts
+++ b/vite-plugin-ember/src/vitepress/code-preview.ts
@@ -23,7 +23,8 @@ const CSS = [
 ].join('');
 
 function ensureStyle() {
-  if (typeof document === 'undefined' || document.getElementById(STYLE_ID)) return;
+  if (typeof document === 'undefined' || document.getElementById(STYLE_ID))
+    return;
   const style = document.createElement('style');
   style.id = STYLE_ID;
   style.textContent = CSS;
@@ -40,14 +41,24 @@ export default defineComponent({
     collapsible: { type: Boolean },
   },
   setup(props, { slots }) {
-    const injectedOwner = inject<object | undefined>(EMBER_OWNER_KEY, undefined);
+    const injectedOwner = inject<object | undefined>(
+      EMBER_OWNER_KEY,
+      undefined,
+    );
     const mountEl = ref<HTMLDivElement | null>(null);
     const error = ref<string | null>(null);
     let cleanup: undefined | { destroy?: () => void };
 
-    let rendererPromise: Promise<{ renderComponent: Function }> | undefined;
+    type RendererModule = {
+      renderComponent: (
+        component: unknown,
+        options: { into: Element; owner?: object },
+      ) => { destroy?: () => void };
+    };
+
+    let rendererPromise: Promise<RendererModule> | undefined;
     function getRenderer() {
-      rendererPromise ??= import('@ember/renderer') as any;
+      rendererPromise ??= import('@ember/renderer') as Promise<RendererModule>;
       return rendererPromise!;
     }
 
@@ -82,7 +93,9 @@ export default defineComponent({
       const children = [];
 
       if (error.value) {
-        children.push(h('div', { class: 'ember-playground__error' }, error.value));
+        children.push(
+          h('div', { class: 'ember-playground__error' }, error.value),
+        );
       }
 
       children.push(h('div', { ref: mountEl }));
@@ -96,7 +109,9 @@ export default defineComponent({
             ]),
           );
         } else {
-          children.push(h('div', { class: 'ember-playground__source' }, slots.default()));
+          children.push(
+            h('div', { class: 'ember-playground__source' }, slots.default()),
+          );
         }
       }
 

--- a/vite-plugin-ember/src/vitepress/ember-fence.ts
+++ b/vite-plugin-ember/src/vitepress/ember-fence.ts
@@ -2,13 +2,24 @@ import { createHash } from 'node:crypto';
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { demoRegistry } from '../index.js';
-import MarkdownIt from 'markdown-it';
+import type MarkdownIt from 'markdown-it';
+import type { MarkdownItAsync } from 'markdown-it-async';
+
+/**
+ * Accepted markdown-it instance shape.
+ *
+ * VitePress v1 passes a `MarkdownIt` instance; VitePress v2 switched to
+ * `MarkdownItAsync` (see vuejs/vitepress#4507), whose `options.highlight`
+ * may return `Promise<string>`. The two are structurally incompatible at
+ * the `options.highlight` boundary, so accept the union here.
+ */
+export type MarkdownItLike = MarkdownIt | MarkdownItAsync;
 
 /** Fence render rule – extracted from the MarkdownIt instance shape. */
-type RenderRule = NonNullable<MarkdownIt['renderer']['rules']['fence']>;
+type RenderRule = NonNullable<MarkdownItLike['renderer']['rules']['fence']>;
 
 /** Core ruler state – extracted via Core.State constructor. */
-type StateCore = InstanceType<MarkdownIt['core']['State']>;
+type StateCore = InstanceType<MarkdownItLike['core']['State']>;
 
 function makeVirtualId(code: string, lang: 'gjs' | 'gts') {
   const hash = createHash('sha1').update(code).digest('hex').slice(0, 8);
@@ -58,7 +69,7 @@ function renderSourceBlock(
 }
 
 /** Markdown-it plugin: ```gjs live → <CodePreview /> */
-export function emberFence(md: MarkdownIt, component = 'CodePreview') {
+export function emberFence(md: MarkdownItLike, component = 'CodePreview') {
   const originalFence = md.renderer.rules.fence!;
 
   // Pre-compile regex once per plugin instance.


### PR DESCRIPTION
VitePress v2 switched to markdown-it-async (vuejs/vitepress#4507), whose options.highlight may return Promise<string>. This caused TS2345 when passing the VitePress md instance to emberFence(md). Accept MarkdownIt | MarkdownItAsync via a new MarkdownItLike type and widen the vitepress peer range. Also tighten code-preview renderer types to satisfy no-unsafe-function-type. Closes #47