### PR TITLE
fix(code-preview): isolate styles via vp-raw and scope source styles …

### DIFF
--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -2,19 +2,18 @@
  * Docs-side overrides for vite-plugin-ember's <CodePreview>.
  *
  * The plugin intentionally ships minimal defaults for the non-collapsible
- * source wrapper so consumers can style it however they want. These rules
- * give our own docs the same "rendered demo above, syntax-highlighted source
- * below, divided by a thin border" look that the collapsible variant uses.
+ * source wrapper (just a styleless `.ember-playground__code` hook) so
+ * consumers can style it however they want. These rules give our own docs
+ * the same "rendered demo above, syntax-highlighted source below, divided
+ * by a thin border" look that the collapsible variant uses.
  */
 
-/* Non-collapsible: the source <div> is the last child of .ember-playground
- * and contains a Shiki language block. */
-.ember-playground > div:last-child:has(> div[class*='language-']) {
+.ember-playground__code {
   margin-top: 12px;
   border-top: 1px solid var(--vp-c-divider);
 }
 
-.ember-playground > div:last-child > div[class*='language-'] {
+.ember-playground__code > div[class*='language-'] {
   margin: 0;
   border-radius: 0 0 8px 8px;
 }

--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -1,0 +1,20 @@
+/*
+ * Docs-side overrides for vite-plugin-ember's <CodePreview>.
+ *
+ * The plugin intentionally ships minimal defaults for the non-collapsible
+ * source wrapper so consumers can style it however they want. These rules
+ * give our own docs the same "rendered demo above, syntax-highlighted source
+ * below, divided by a thin border" look that the collapsible variant uses.
+ */
+
+/* Non-collapsible: the source <div> is the last child of .ember-playground
+ * and contains a Shiki language block. */
+.ember-playground > div:last-child:has(> div[class*='language-']) {
+  margin-top: 12px;
+  border-top: 1px solid var(--vp-c-divider);
+}
+
+.ember-playground > div:last-child > div[class*='language-'] {
+  margin: 0;
+  border-radius: 0 0 8px 8px;
+}

--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -1,19 +1,24 @@
 /*
- * Docs-side overrides for vite-plugin-ember's <CodePreview>.
+ * Docs-side styling for vite-plugin-ember's <CodePreview>.
  *
- * The plugin intentionally ships minimal defaults for the non-collapsible
- * source wrapper (just a styleless `.ember-playground__code` hook) so
- * consumers can style it however they want. These rules give our own docs
- * the same "rendered demo above, syntax-highlighted source below, divided
- * by a thin border" look that the collapsible variant uses.
+ * The plugin only ships functional defaults (container chrome, error styling,
+ * and the <summary> toggle UX inside the collapsible details). Aesthetic
+ * styling for the two source wrappers — `.ember-playground__code` (non-
+ * collapsible) and `.ember-playground__show-code` (collapsible) — is left to
+ * the consumer theme so both can be treated symmetrically.
+ *
+ * These rules give our docs the "rendered demo above, syntax-highlighted
+ * source below, divided by a thin border" look in both modes.
  */
 
-.ember-playground__code {
+.ember-playground__code,
+.ember-playground__show-code {
   margin-top: 12px;
   border-top: 1px solid var(--vp-c-divider);
 }
 
-.ember-playground__code > div[class*='language-'] {
+.ember-playground__code > div[class*='language-'],
+.ember-playground__show-code div[class*='language-'] {
   margin: 0;
   border-radius: 0 0 8px 8px;
 }

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -2,6 +2,7 @@ import DefaultTheme from 'vitepress/theme';
 import { setupEmber } from 'vite-plugin-ember/setup';
 import GreetingService from '../../demos/greeting-service';
 import type { Theme } from 'vitepress';
+import './custom.css';
 
 export default {
   ...DefaultTheme,

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -12,8 +12,6 @@ A regular code fence without `live` — syntax-highlighted only, not rendered:
 </template>
 ```
 
----
-
 ## Template-only component
 
 The simplest live demo — a `<template>` tag with no class:
@@ -26,8 +24,6 @@ The simplest live demo — a `<template>` tag with no class:
 </template>
 ```
 
----
-
 ## Live + Preview
 
 Adding `preview` shows both the rendered output and the source code:
@@ -39,8 +35,6 @@ Adding `preview` shows both the rendered output and the source code:
   </p>
 </template>
 ```
-
----
 
 ## Toggle button
 
@@ -71,8 +65,6 @@ export default class Toggle extends Component {
   </template>
 }
 ```
-
----
 
 ## Step counter (with preview)
 
@@ -135,8 +127,6 @@ export default class StepCounter extends Component {
   </template>
 }
 ```
-
----
 
 ## File-based demos
 

--- a/vite-plugin-ember/src/vitepress/code-preview.ts
+++ b/vite-plugin-ember/src/vitepress/code-preview.ts
@@ -26,10 +26,10 @@ const STYLE_ID = 'vite-plugin-ember-code-preview';
 const CSS = [
   '.ember-playground{padding:12px;border:1px solid var(--vp-c-divider);border-radius:10px}',
   '.ember-playground__error{padding:8px 12px;margin-bottom:8px;border-radius:6px;background:var(--vp-c-danger-soft);color:var(--vp-c-danger-1);font-size:13px;font-family:var(--vp-font-family-mono);white-space:pre-wrap;word-break:break-word}',
-  '.ember-playground__source{margin-top:12px;border-top:1px solid var(--vp-c-divider)}',
-  '.ember-playground__source summary{padding:8px 0 4px;cursor:pointer;font-size:13px;color:var(--vp-c-text-2);user-select:none}',
-  '.ember-playground__source summary:hover{color:var(--vp-c-text-1)}',
-  ".ember-playground__source div[class*='language-']{margin:0;border-radius:0 0 8px 8px}",
+  '.ember-playground__show-code{margin-top:12px;border-top:1px solid var(--vp-c-divider)}',
+  '.ember-playground__show-code summary{padding:8px 0 4px;cursor:pointer;font-size:13px;color:var(--vp-c-text-2);user-select:none}',
+  '.ember-playground__show-code summary:hover{color:var(--vp-c-text-1)}',
+  ".ember-playground__show-code div[class*='language-']{margin:0;border-radius:0 0 8px 8px}",
 ].join('');
 
 function ensureStyle() {
@@ -93,20 +93,18 @@ export default defineComponent({
         );
       }
 
-      children.push(h('div', { ref: mountEl }));
+      children.push(h('div', { ref: mountEl, class: 'vp-raw' }));
 
       if (slots.default) {
         if (props.collapsible) {
           children.push(
-            h('details', { class: 'ember-playground__source' }, [
+            h('details', { class: 'ember-playground__show-code' }, [
               h('summary', 'Show code'),
               slots.default(),
             ]),
           );
         } else {
-          children.push(
-            h('div', { class: 'ember-playground__source' }, slots.default()),
-          );
+          children.push(h('div', slots.default()));
         }
       }
 

--- a/vite-plugin-ember/src/vitepress/code-preview.ts
+++ b/vite-plugin-ember/src/vitepress/code-preview.ts
@@ -104,7 +104,9 @@ export default defineComponent({
             ]),
           );
         } else {
-          children.push(h('div', slots.default()));
+          children.push(
+            h('div', { class: 'ember-playground__code' }, slots.default()),
+          );
         }
       }
 

--- a/vite-plugin-ember/src/vitepress/code-preview.ts
+++ b/vite-plugin-ember/src/vitepress/code-preview.ts
@@ -23,13 +23,20 @@ const inBrowser = typeof document !== 'undefined';
 export { EMBER_OWNER_KEY };
 
 const STYLE_ID = 'vite-plugin-ember-code-preview';
+// Plugin-shipped CSS is intentionally limited to "functional" defaults:
+//   • container chrome for `.ember-playground`
+//   • error message styling
+//   • `<summary>` UX inside the collapsible details (cursor, color, hover)
+//
+// Aesthetic / layout styling for the source wrappers
+// (`.ember-playground__code` for the non-collapsible case and
+// `.ember-playground__show-code` for the collapsible case) is left to the
+// consumer's theme so that both wrappers can be treated symmetrically.
 const CSS = [
   '.ember-playground{padding:12px;border:1px solid var(--vp-c-divider);border-radius:10px}',
   '.ember-playground__error{padding:8px 12px;margin-bottom:8px;border-radius:6px;background:var(--vp-c-danger-soft);color:var(--vp-c-danger-1);font-size:13px;font-family:var(--vp-font-family-mono);white-space:pre-wrap;word-break:break-word}',
-  '.ember-playground__show-code{margin-top:12px;border-top:1px solid var(--vp-c-divider)}',
   '.ember-playground__show-code summary{padding:8px 0 4px;cursor:pointer;font-size:13px;color:var(--vp-c-text-2);user-select:none}',
   '.ember-playground__show-code summary:hover{color:var(--vp-c-text-1)}',
-  ".ember-playground__show-code div[class*='language-']{margin:0;border-radius:0 0 8px 8px}",
 ].join('');
 
 function ensureStyle() {


### PR DESCRIPTION
…to collapsible

Combines two community proposals (#41, #46):

- Add the VitePress `vp-raw` class to the mount element so VitePress's global content styles don't leak into rendered Ember components (vuejs/vitepress raw escape hatch).
- Rename `.ember-playground__source` to `.ember-playground__show-code` and only apply it to the collapsible <details> wrapper. The non-collapsible source wrapper is left unstyled so consumers can decide their own look (fixes the unwanted top border seen in ember-intl docs).

Note: this renames a public CSS hook (`__source` -> `__show-code`) and drops default styles from the non-collapsible source wrapper. Both should be called out in release notes.

Closes #41, closes #46