### PR TITLE
docs(meta): sharpen VitePress framing + expand npm keywords (refs #64)

### DIFF
--- a/vite-plugin-ember/README.md
+++ b/vite-plugin-ember/README.md
@@ -9,6 +9,12 @@ Write `.gjs` / `.gts` code fences in markdown and see them rendered on the page 
 
 **[View the live documentation →](https://aklkv.github.io/vite-plugin-ember/)**
 
+## Is this for me?
+
+- ✅ **You're using VitePress** for docs or a blog and you want to embed live Ember components — yes, this is exactly what this plugin does.
+- ☑️ **You're using plain Vite** (not VitePress) and want `.gjs`/`.gts` support — the core resolver and `.gjs`/`.gts` transform also work standalone; the VitePress-specific helpers (`<CodePreview>`, `setupEmber`, `emberFence`) live under separate subpath exports that you can simply not import.
+- ❌ **You want to build a full Ember app with Vite** as a replacement for `ember-cli` / `@embroider/vite` — that's a much larger problem and is **not** this plugin's goal.
+
 ## Features
 
 - **Inline code fences** — use ` ```gjs live ` in markdown for instant interactive previews

--- a/vite-plugin-ember/package.json
+++ b/vite-plugin-ember/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vite-plugin-ember",
   "version": "0.5.4",
-  "description": "Vite plugin for rendering live Ember components in VitePress documentation",
+  "description": "VitePress plugin for live, interactive Ember components in your documentation — write .gjs/.gts in markdown and see them render",
   "license": "MIT",
   "type": "module",
   "author": "Alexey Kulakov",
@@ -15,13 +15,23 @@
     "url": "https://github.com/aklkv/vite-plugin-ember/issues"
   },
   "keywords": [
+    "vitepress",
+    "vitepress-plugin",
     "vite",
     "vite-plugin",
     "ember",
+    "emberjs",
+    "ember-source",
+    "ember-modifier",
     "glimmer",
-    "vitepress",
+    "glimmer-component",
+    "template-tag",
     "gjs",
-    "gts"
+    "gts",
+    "documentation",
+    "docs",
+    "live-preview",
+    "playground"
   ],
   "sideEffects": false,
   "main": "dist/index.js",


### PR DESCRIPTION
Address the "unclear scope / hard to discover" feedback by tightening the package metadata and README, without renaming the package.

- package.json description: lead with "VitePress plugin" and mention the concrete output (.gjs/.gts in markdown), so it reads correctly in npm search results and on the package page.
- package.json keywords: add the search terms people actually type when looking for this kind of tool — `vitepress-plugin`, `emberjs`, `ember-source`, `ember-modifier`, `glimmer-component`, `template-tag`, `documentation`, `docs`, `live-preview`, `playground`.
- README: add an explicit "Is this for me?" section right under the intro that answers the three obvious questions a visitor has: yes if you're on VitePress; yes-ish if you're on plain Vite and only want the `.gjs`/`.gts` transform; no if you're trying to replace ember-cli / @embroider/vite for a full Ember app.

No code or API changes.