### PR TITLE
fix(ssr): inline inBrowser check to avoid top-level vitepress import (#40)

### DIFF
--- a/vite-plugin-ember/src/vitepress/code-preview.ts
+++ b/vite-plugin-ember/src/vitepress/code-preview.ts
@@ -7,8 +7,15 @@ import {
   h,
   type PropType,
 } from 'vue';
-import { inBrowser } from 'vitepress';
 import { EMBER_OWNER_KEY } from './constants.js';
+
+// Inlined to avoid a top-level static import from `vitepress`. The `vitepress`
+// package uses conditional exports, and when this module is loaded by Node's
+// native ESM loader (e.g. during SSR after Vite externalizes it as an npm dep),
+// Node resolves to an entry that does not re-export `inBrowser`, which crashes
+// at parse time. The check itself is a one-liner, so we just inline it.
+// See https://github.com/aklkv/vite-plugin-ember/issues/40#issuecomment-4517523496
+const inBrowser = typeof document !== 'undefined';
 
 export { EMBER_OWNER_KEY };
 


### PR DESCRIPTION
## Why

After v0.5.2, when a downstream project statically imports `CodePreview` (e.g. registers it from a custom theme or imports it from a `<script setup>` in a page), `code-preview.js` enters the SSR module graph and is parsed directly by Node's native ESM loader.

Node then evaluates:

```js
import { inBrowser } from 'vitepress';
```

and throws:

```
SyntaxError: The requested module 'vitepress' does not provide an export named 'inBrowser'
```

`vitepress` uses conditional exports — Vite's pipeline resolves a client-aware entry that exposes `inBrowser`, but Node's default conditions resolve a different entry that does not.

Reported in [#40 (comment)](https://github.com/aklkv/vite-plugin-ember/issues/40#issuecomment-4517523496).

## What

`inBrowser` from `vitepress` is literally `typeof document !== 'undefined'`. Inlining it removes the static import, eliminating the SSR parse error and dropping an unneeded dependency surface on `vitepress`'s internal export shape.

## Verification

Reproduced locally by adding a static `import CodePreview from 'vite-plugin-ember/components/CodePreview'` to the docs theme — without the fix Node throws at SSR parse time; with the fix `vitepress build` completes cleanly.

Refs #40