### PR TITLE
feat(babel): extensible Babel pipeline (presets, parser plugins, ordering)

### DIFF
--- a/docs/guide/plugin-api.md
+++ b/docs/guide/plugin-api.md
@@ -10,11 +10,13 @@ import vitePluginEmber from 'vite-plugin-ember';
 
 ### Options
 
-| Option         | Type                     | Default                                          | Description                                                                                                  |
-| -------------- | ------------------------ | ------------------------------------------------ | ------------------------------------------------------------------------------------------------------------ |
-| `compilerPath` | `string`                 | `'ember-source/dist/ember-template-compiler.js'` | Path to the Ember template compiler module. Override this only if you need a custom or pre-release compiler. |
-| `resolve`      | `Record<string, string>` | `{}`                                             | Custom import resolution map. Keys are bare specifiers, values are resolved paths or package names.          |
-| `babelPlugins` | `any[]`                  | `[]`                                             | Additional Babel plugins appended after the built-in template compilation and decorator transforms.          |
+| Option          | Type                                                              | Default                                          | Description                                                                                                                                                |
+| --------------- | ----------------------------------------------------------------- | ------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `compilerPath`  | `string`                                                          | `'ember-source/dist/ember-template-compiler.js'` | Path to the Ember template compiler module. Override this only if you need a custom or pre-release compiler.                                               |
+| `resolve`       | `Record<string, string>`                                          | `{}`                                             | Custom import resolution map. Keys are bare specifiers, values are resolved paths or package names.                                                        |
+| `babelPlugins`  | `PluginItem[] \| { before?: PluginItem[]; after?: PluginItem[] }` | `[]`                                             | Additional Babel plugins. Array form appends after the built-ins; object form lets you place plugins before or after the built-in template/decorator pass. |
+| `babelPresets`  | `PluginItem[]`                                                    | `[]`                                             | Additional Babel presets forwarded to the `.gjs`/`.gts` transform.                                                                                         |
+| `parserPlugins` | `ParserPlugin[]`                                                  | `[]`                                             | Additional Babel parser plugins (e.g. `'decorators-legacy'`, `'pipelineOperator'`). Appended to the built-in parser plugins.                               |
 
 ### `resolve` option
 
@@ -52,6 +54,51 @@ vitePluginEmber({
 ```
 
 These plugins run after the built-in template compilation and decorator transforms.
+
+If you need a plugin to run **before** the built-ins (e.g. an instrumentation transform that needs to see the original source), use the object form:
+
+```ts
+vitePluginEmber({
+  babelPlugins: {
+    before: ['my-instrumentation-plugin'],
+    after: ['ember-concurrency/async-arrow-task-transform'],
+  },
+});
+```
+
+The full Babel plugin order is:
+
+1. `before` plugins
+2. `babel-plugin-ember-template-compilation`
+3. `decorator-transforms`
+4. `after` plugins
+5. `@babel/plugin-transform-typescript` (only for `.gts`)
+
+### `babelPresets` option
+
+Forward additional Babel presets to the `.gjs`/`.gts` transform. Presets follow Babel's normal ordering rules (applied last to first).
+
+```ts
+vitePluginEmber({
+  babelPresets: [['@babel/preset-env', { targets: { esmodules: true } }]],
+});
+```
+
+### `parserPlugins` option
+
+Enable additional Babel parser plugins for syntax that is not on by default — for example, legacy decorators, the pipeline operator, or other proposals.
+
+```ts
+vitePluginEmber({
+  parserPlugins: ['decorators-legacy'],
+});
+```
+
+The built-in parser plugins (`classProperties`, `classPrivateProperties`, `classPrivateMethods`, plus `typescript` for `.gts`) are always included; yours are appended.
+
+### Why not auto-load `babel.config.js`?
+
+`vite-plugin-ember` owns the `.gjs`/`.gts` pipeline; it does not read your project's `babel.config.js` or `.babelrc`. Those files belong to your application build and frequently contain transforms that don't apply (or actively conflict) here. Provide what you need explicitly via the options above.
 
 ### What the plugin does
 

--- a/vite-plugin-ember/src/index.ts
+++ b/vite-plugin-ember/src/index.ts
@@ -84,19 +84,66 @@ export interface VitePluginEmberOptions {
 
   /**
    * Additional Babel plugins to run during .gjs/.gts transformation.
-   * These are appended after the built-in template compilation and
-   * decorator transform plugins.
+   *
+   * Accepts either an array (appended **after** the built-in template
+   * compilation and decorator transform plugins — same as previous behaviour)
+   * or an object with `before` / `after` arrays for fine-grained ordering
+   * relative to the built-ins:
+   *
+   * 1. `before` plugins
+   * 2. `babel-plugin-ember-template-compilation`
+   * 3. `decorator-transforms`
+   * 4. `after` plugins
+   * 5. `@babel/plugin-transform-typescript` (only for `.gts`)
    *
    * @example
    * ```ts
    * vitePluginEmber({
-   *   babelPlugins: [
-   *     'ember-concurrency/async-arrow-task-transform',
-   *   ]
+   *   babelPlugins: ['ember-concurrency/async-arrow-task-transform'],
+   * })
+   *
+   * // or, with explicit ordering:
+   * vitePluginEmber({
+   *   babelPlugins: {
+   *     before: ['my-instrumentation-plugin'],
+   *     after: ['ember-concurrency/async-arrow-task-transform'],
+   *   },
    * })
    * ```
    */
-  babelPlugins?: PluginItem[];
+  babelPlugins?: PluginItem[] | { before?: PluginItem[]; after?: PluginItem[] };
+
+  /**
+   * Additional Babel presets to apply during .gjs/.gts transformation.
+   * Presets are passed through to Babel as-is and run after plugins,
+   * following Babel's normal preset ordering (last to first).
+   *
+   * @example
+   * ```ts
+   * vitePluginEmber({
+   *   babelPresets: [['@babel/preset-env', { targets: { esmodules: true } }]],
+   * })
+   * ```
+   */
+  babelPresets?: PluginItem[];
+
+  /**
+   * Additional Babel parser plugins (forwarded to `parserOpts.plugins`).
+   * Use this to enable syntax features such as legacy decorators,
+   * the pipeline operator, or other proposals that are not enabled by
+   * default.
+   *
+   * The built-in parser plugins (class fields/private methods, plus
+   * `typescript` for `.gts`) are always included; these are appended.
+   *
+   * @example
+   * ```ts
+   * vitePluginEmber({
+   *   parserPlugins: ['decorators-legacy'],
+   * })
+   * ```
+   */
+  parserPlugins?: NonNullable<ParserOptions['plugins']>;
 }
 
 export default function vitePluginEmber(
@@ -128,10 +175,12 @@ export default function vitePluginEmber(
   type ParserPluginList = NonNullable<ParserOptions['plugins']>;
   let babelConfigGJS: {
     plugins: PluginItem[];
+    presets: PluginItem[];
     parserPlugins: ParserPluginList;
   };
   let babelConfigGTS: {
     plugins: PluginItem[];
+    presets: PluginItem[];
     parserPlugins: ParserPluginList;
   };
 
@@ -152,18 +201,34 @@ export default function vitePluginEmber(
       'classPrivateMethods',
     ];
 
+    // Normalize `babelPlugins` (array | { before, after }) into ordered slots
+    // around the built-ins.
+    let userBefore: PluginItem[] = [];
+    let userAfter: PluginItem[] = [];
+    if (Array.isArray(options.babelPlugins)) {
+      userAfter = options.babelPlugins;
+    } else if (options.babelPlugins) {
+      userBefore = options.babelPlugins.before ?? [];
+      userAfter = options.babelPlugins.after ?? [];
+    }
+
     const basePlugins: PluginItem[] = [
+      ...userBefore,
       [templateCompilation as PluginItem, getTemplateCompilationOpts()],
       [
         'module:decorator-transforms',
         { runtime: { import: 'decorator-transforms/runtime' } },
       ],
-      ...(options.babelPlugins ?? []),
+      ...userAfter,
     ];
+
+    const presets: PluginItem[] = [...(options.babelPresets ?? [])];
+    const userParserPlugins = options.parserPlugins ?? [];
 
     babelConfigGJS = {
       plugins: basePlugins,
-      parserPlugins: baseParserPlugins,
+      presets,
+      parserPlugins: [...baseParserPlugins, ...userParserPlugins],
     };
 
     babelConfigGTS = {
@@ -178,7 +243,8 @@ export default function vitePluginEmber(
           },
         ],
       ],
-      parserPlugins: [...baseParserPlugins, 'typescript'],
+      presets,
+      parserPlugins: [...baseParserPlugins, 'typescript', ...userParserPlugins],
     };
   }
 
@@ -557,6 +623,7 @@ export default function vitePluginEmber(
         babelrc: false,
         configFile: false,
         plugins: cfg.plugins,
+        presets: cfg.presets,
         parserOpts: {
           sourceType: 'module',
           plugins: cfg.parserPlugins,


### PR DESCRIPTION
## Why

Consumers occasionally need to extend the Babel pipeline beyond what `babelPlugins` allows today — for example, enabling `decorators-legacy` parser syntax, applying a preset, or running an instrumentation plugin **before** the built-in template/decorator transforms.

We deliberately do **not** auto-load `babel.config.js` (see [discussion](https://github.com/aklkv/vite-plugin-ember/issues/40)): this plugin owns the `.gjs`/`.gts` pipeline and inheriting an app-level Babel config silently would cause more bugs than it solves. Instead, we expose a few small, explicit knobs.

## What

Three new (or extended) options on `vitePluginEmber({ ... })`:

### `babelPlugins` — now also accepts an ordering object

```ts
vitePluginEmber({
  babelPlugins: {
    before: ['my-instrumentation-plugin'],
    after:  ['ember-concurrency/async-arrow-task-transform'],
  },
});
```

Full ordering:

1. `before` plugins
2. `babel-plugin-ember-template-compilation`
3. `decorator-transforms`
4. `after` plugins
5. `@babel/plugin-transform-typescript` (only for `.gts`)

The previous `PluginItem[]` form is still supported and behaves exactly as before (treated as `after`).

### `babelPresets`

```ts
vitePluginEmber({
  babelPresets: [['@babel/preset-env', { targets: { esmodules: true } }]],
});
```

### `parserPlugins`

```ts
vitePluginEmber({
  parserPlugins: ['decorators-legacy'],
});
```

Appended to the built-in parser plugins (`classProperties`, `classPrivateProperties`, `classPrivateMethods`, plus `typescript` for `.gts`).

## Backwards compatibility

Fully backwards compatible. The existing `babelPlugins: PluginItem[]` shape behaves identically; the object form is purely additive; the two new options default to empty.

## Docs

Updated `docs/guide/plugin-api.md` with the new options, ordering diagram, and a short rationale for why we don't read `babel.config.js`.

## Verification

- `pnpm build` (tsc) — clean
- `pnpm lint` (format / types / js) — clean