### PR TITLE
feat(ember-live-compiler): extract bundler-agnostic compile engine (Phase 0)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,8 +26,8 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
-      - name: Build plugin
-        run: pnpm -C vite-plugin-ember build
+      - name: Build (all workspace packages)
+        run: pnpm build
 
       - name: Lint
         run: pnpm lint
@@ -47,8 +47,5 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
-      - name: Build plugin
-        run: pnpm -C vite-plugin-ember build
-
-      - name: Build docs
-        run: pnpm -C docs build
+      - name: Build (all workspace packages)
+        run: pnpm build

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -30,8 +30,8 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
-      - name: Build plugin
-        run: pnpm -C vite-plugin-ember build
+      - name: Build plugin (and engine deps)
+        run: pnpm -F vite-plugin-ember... build
 
       - name: Build docs
         run: pnpm -C docs build

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,8 +34,8 @@ jobs:
           cache: pnpm
       - run: npm install -g npm@latest # ensure that the globally installed npm is new enough to support OIDC
       - run: pnpm install --frozen-lockfile
-      - name: Build plugin
-        run: pnpm -C vite-plugin-ember build
+      - name: Build (all workspace packages)
+        run: pnpm build
       - name: Publish to NPM
         run: NPM_CONFIG_PROVENANCE=true pnpm release-plan publish
         env:

--- a/ember-live-compiler/.prettierignore
+++ b/ember-live-compiler/.prettierignore
@@ -1,0 +1,2 @@
+node_modules
+dist

--- a/ember-live-compiler/README.md
+++ b/ember-live-compiler/README.md
@@ -1,0 +1,26 @@
+# ember-live-compiler
+
+> **Status: 0.0.1 — scaffold only.** The public surface is being extracted from
+> [`vite-plugin-ember`](../vite-plugin-ember). Today only `createOwner` is
+> implemented; the build-time and runtime compile pipelines land in 0.1.
+
+A bundler-agnostic engine for compiling and rendering `.gjs` / `.gts` Ember
+components. It will be the shared core that powers live Ember demos in:
+
+- VitePress (via `vite-plugin-ember`)
+- Docusaurus (via `docusaurus-plugin-ember`, planned)
+- Storybook (after [storybookjs/storybook#33048](https://github.com/storybookjs/storybook/pull/33048))
+- Backstage TechDocs (via a runtime-only addon, planned)
+- [kolay](https://github.com/universal-ember/kolay) and `ember-cli-addon-docs` (as a shared dependency, planned)
+
+## Subpath exports
+
+| Import                         | Environment | Purpose                                               |
+| ------------------------------ | ----------- | ----------------------------------------------------- |
+| `ember-live-compiler`          | Node        | Build-time `compile()` for bundler plugins.           |
+| `ember-live-compiler/runtime`  | Browser     | In-browser `compile()` + `render()`.                  |
+| `ember-live-compiler/resolver` | Both        | Pure helpers for resolving `@ember/*` / `@glimmer/*`. |
+
+## License
+
+MIT

--- a/ember-live-compiler/eslint.config.mjs
+++ b/ember-live-compiler/eslint.config.mjs
@@ -1,0 +1,26 @@
+import { defineConfig, globalIgnores } from 'eslint/config';
+import js from '@eslint/js';
+import prettier from 'eslint-config-prettier';
+import ts from 'typescript-eslint';
+import globals from 'globals';
+
+export default defineConfig([
+  globalIgnores(['node_modules/', 'dist/']),
+  js.configs.recommended,
+  prettier,
+  {
+    files: ['**/*.ts'],
+    extends: [...ts.configs.recommended],
+    languageOptions: {
+      ecmaVersion: 'latest',
+      sourceType: 'module',
+      parserOptions: {
+        projectService: true,
+        tsconfigRootDir: import.meta.dirname,
+      },
+      globals: {
+        ...globals.node,
+      },
+    },
+  },
+]);

--- a/ember-live-compiler/package.json
+++ b/ember-live-compiler/package.json
@@ -1,37 +1,31 @@
 {
-  "name": "vite-plugin-ember",
-  "version": "0.6.0",
-  "description": "VitePress plugin for live, interactive Ember components in your documentation — write .gjs/.gts in markdown and see them render",
+  "name": "ember-live-compiler",
+  "version": "0.0.1",
+  "private": true,
+  "description": "Bundler-agnostic engine for compiling and rendering .gjs/.gts Ember components — the core that powers live Ember demos in VitePress, Docusaurus, Storybook, Backstage TechDocs, kolay, and more.",
   "license": "MIT",
   "type": "module",
   "author": "Alexey Kulakov",
-  "homepage": "https://github.com/aklkv/vite-plugin-ember#readme",
+  "homepage": "https://github.com/aklkv/vite-plugin-ember/tree/main/ember-live-compiler#readme",
   "repository": {
     "type": "git",
     "url": "https://github.com/aklkv/vite-plugin-ember.git",
-    "directory": "vite-plugin-ember"
+    "directory": "ember-live-compiler"
   },
   "bugs": {
     "url": "https://github.com/aklkv/vite-plugin-ember/issues"
   },
   "keywords": [
-    "vitepress",
-    "vitepress-plugin",
-    "vite",
-    "vite-plugin",
     "ember",
     "emberjs",
     "ember-source",
-    "ember-modifier",
     "glimmer",
-    "glimmer-component",
-    "template-tag",
     "gjs",
     "gts",
-    "documentation",
-    "docs",
+    "template-tag",
+    "compiler",
     "live-preview",
-    "playground"
+    "documentation"
   ],
   "sideEffects": false,
   "main": "dist/index.js",
@@ -41,21 +35,13 @@
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
     },
-    "./components/CodePreview": {
-      "types": "./dist/vitepress/code-preview.d.ts",
-      "default": "./dist/vitepress/code-preview.js"
+    "./runtime": {
+      "types": "./dist/runtime/index.d.ts",
+      "default": "./dist/runtime/index.js"
     },
-    "./owner": {
-      "types": "./dist/vitepress/create-owner.d.ts",
-      "default": "./dist/vitepress/create-owner.js"
-    },
-    "./setup": {
-      "types": "./dist/vitepress/setup.d.ts",
-      "default": "./dist/vitepress/setup.js"
-    },
-    "./*": {
-      "types": "./dist/*.d.ts",
-      "default": "./dist/*.js"
+    "./resolver": {
+      "types": "./dist/resolver/index.d.ts",
+      "default": "./dist/resolver/index.js"
     }
   },
   "files": [
@@ -78,37 +64,17 @@
     "@babel/plugin-transform-typescript": "^7.28.6",
     "babel-plugin-ember-template-compilation": "^4.0.0",
     "content-tag": "^4.2.0",
-    "ember-live-compiler": "workspace:*",
     "decorator-transforms": "^2.3.2"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
     "@types/babel__core": "^7.20.5",
-    "@types/markdown-it": "^14.1.2",
     "@types/node": "^25.9.1",
     "concurrently": "^9.2.1",
-    "ember-source": "7.0.0",
     "eslint": "^10.4.0",
     "eslint-config-prettier": "^10.1.8",
     "globals": "^17.6.0",
-    "markdown-it": "^14.1.1",
-    "markdown-it-async": "^2.2.0",
     "typescript": "^6.0.3",
-    "typescript-eslint": "^8.59.4",
-    "vite": "^8.0.14",
-    "vitepress": "^1.6.4",
-    "vue": "^3.5.34"
-  },
-  "peerDependencies": {
-    "@glimmer/component": ">=1",
-    "ember-source": ">=6.12.0",
-    "vite": ">=5",
-    "vitepress": ">=1 || >=2.0.0-alpha",
-    "vue": ">=3"
-  },
-  "peerDependenciesMeta": {
-    "@glimmer/component": {
-      "optional": true
-    }
+    "typescript-eslint": "^8.59.4"
   }
 }

--- a/ember-live-compiler/package.json
+++ b/ember-live-compiler/package.json
@@ -66,6 +66,14 @@
     "content-tag": "^4.2.0",
     "decorator-transforms": "^2.3.2"
   },
+  "peerDependencies": {
+    "ember-source": ">= 6.8.0"
+  },
+  "peerDependenciesMeta": {
+    "ember-source": {
+      "optional": true
+    }
+  },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
     "@types/babel__core": "^7.20.5",

--- a/ember-live-compiler/src/compile.node.ts
+++ b/ember-live-compiler/src/compile.node.ts
@@ -1,0 +1,249 @@
+/**
+ * `ember-live-compiler` — Node / build-time compile pipeline.
+ *
+ * Consumed by bundler plugins (Vite, Webpack, Rollup, esbuild) that need to
+ * turn `.gjs` / `.gts` source into a Babel-compiled JavaScript module.
+ *
+ * The engine is bundler-agnostic and DOM-free: callers are responsible for
+ * locating their project's `ember-source` template compiler and for any
+ * file-id sniffing / virtual-module bookkeeping their bundler requires.
+ *
+ * Usage:
+ *
+ * ```ts
+ * import { createNodeCompiler } from 'ember-live-compiler';
+ *
+ * const compiler = createNodeCompiler({
+ *   templateCompiler: { compiler }, // or { compilerPath }
+ * });
+ *
+ * const result = await compiler.compile(source, {
+ *   filename: '/abs/path/MyButton.gts',
+ *   kind: 'gts',
+ *   sourceMaps: true,
+ * });
+ * ```
+ */
+
+import templateCompilation from 'babel-plugin-ember-template-compilation';
+import { transformAsync } from '@babel/core';
+import { Preprocessor } from 'content-tag';
+
+import type { ParserOptions, PluginItem } from '@babel/core';
+
+type ParserPluginList = NonNullable<ParserOptions['plugins']>;
+
+/**
+ * Source kind passed to {@link NodeCompiler.compile}. The consumer is
+ * responsible for sniffing this from the file id / extension.
+ */
+export type CompileKind =
+  | 'gjs'
+  | 'gts'
+  /**
+   * A `.js` file emitted by a V2 Ember addon with
+   * `targetFormat: 'hbs'` — i.e. it contains `precompileTemplate()` calls
+   * that need template-compilation but no content-tag preprocessing and
+   * no decorator transform.
+   */
+  | 'precompiled-template';
+
+/**
+ * Options passed once to {@link createNodeCompiler}. Heavy work (building the
+ * Babel plugin/preset lists) happens here so per-file `compile()` calls stay
+ * cheap.
+ */
+export interface NodeCompilerOptions {
+  /**
+   * How `babel-plugin-ember-template-compilation` should locate the Ember
+   * template compiler. Pass either a preloaded `compiler` module (fast path
+   * for Ember ≤ 6.x) or a `compilerPath` (Ember 7+ ESM, lazily loaded by the
+   * Babel plugin). When both are omitted the Babel plugin runs its own
+   * default ember-source resolution.
+   */
+  templateCompiler?: { compiler?: unknown; compilerPath?: string };
+
+  /**
+   * Additional Babel plugins. Either an array (appended **after** the
+   * built-ins, matching legacy behavior) or `{ before, after }` for fine
+   * ordering relative to the built-ins:
+   *
+   * 1. `before` plugins
+   * 2. `babel-plugin-ember-template-compilation`
+   * 3. `module:decorator-transforms`
+   * 4. `after` plugins
+   * 5. `@babel/plugin-transform-typescript` (only for `.gts`)
+   */
+  babelPlugins?: PluginItem[] | { before?: PluginItem[]; after?: PluginItem[] };
+
+  /** Additional Babel presets (forwarded as-is). */
+  babelPresets?: PluginItem[];
+
+  /**
+   * Additional Babel parser plugins (forwarded to `parserOpts.plugins`).
+   * The built-ins (`classProperties`, `classPrivateProperties`,
+   * `classPrivateMethods`, plus `typescript` for `.gts`) are always
+   * included; these are appended.
+   */
+  parserPlugins?: ParserPluginList;
+}
+
+/** Per-file options for {@link NodeCompiler.compile}. */
+export interface CompileFileOptions {
+  /** Absolute path used for source-map `filename` and error reporting. */
+  filename: string;
+  /** What kind of source this is. */
+  kind: CompileKind;
+  /** Whether to produce a source map. Defaults to `true`. */
+  sourceMaps?: boolean;
+}
+
+/** Result of a single compile. */
+export interface CompileResult {
+  code: string;
+  /** Babel's source-map object. Shape matches `BabelFileResult['map']`. */
+  map?: unknown;
+}
+
+/** Stateful compiler returned by {@link createNodeCompiler}. */
+export interface NodeCompiler {
+  /**
+   * Compile a single source file. Returns `null` when Babel produces no
+   * output (matches Vite/Rollup's `transform` contract).
+   *
+   * Throws on content-tag or Babel failures — the caller is expected to
+   * narrow / report those (e.g. via Rollup's `this.error`).
+   */
+  compile(
+    source: string,
+    opts: CompileFileOptions,
+  ): Promise<CompileResult | null>;
+}
+
+const BASE_PARSER_PLUGINS: ParserPluginList = [
+  'classProperties',
+  'classPrivateProperties',
+  'classPrivateMethods',
+];
+
+/**
+ * Build the shared Babel configs (one for `.gjs`, one for `.gts`,
+ * one for `precompiled-template` `.js`) once at compiler-creation time.
+ */
+export function createNodeCompiler(
+  options: NodeCompilerOptions = {},
+): NodeCompiler {
+  const preprocessor = new Preprocessor();
+
+  const templateCompilationOpts: Record<string, unknown> = (() => {
+    const tc = options.templateCompiler;
+    if (!tc) return {};
+    if (tc.compiler) return { compiler: tc.compiler };
+    if (tc.compilerPath) return { compilerPath: tc.compilerPath };
+    return {};
+  })();
+
+  // Normalize `babelPlugins` (array | { before, after }) into ordered slots
+  // around the built-ins.
+  let userBefore: PluginItem[] = [];
+  let userAfter: PluginItem[] = [];
+  if (Array.isArray(options.babelPlugins)) {
+    userAfter = options.babelPlugins;
+  } else if (options.babelPlugins) {
+    userBefore = options.babelPlugins.before ?? [];
+    userAfter = options.babelPlugins.after ?? [];
+  }
+
+  const basePlugins: PluginItem[] = [
+    ...userBefore,
+    [templateCompilation as PluginItem, templateCompilationOpts],
+    [
+      'module:decorator-transforms',
+      { runtime: { import: 'decorator-transforms/runtime' } },
+    ],
+    ...userAfter,
+  ];
+
+  const presets: PluginItem[] = [...(options.babelPresets ?? [])];
+  const userParserPlugins = options.parserPlugins ?? [];
+
+  const gjsConfig = {
+    plugins: basePlugins,
+    presets,
+    parserPlugins: [...BASE_PARSER_PLUGINS, ...userParserPlugins],
+  };
+
+  const gtsConfig = {
+    plugins: [
+      ...basePlugins,
+      [
+        '@babel/plugin-transform-typescript',
+        {
+          allExtensions: true,
+          onlyRemoveTypeImports: true,
+          allowDeclareFields: true,
+        },
+      ] satisfies PluginItem,
+    ] as PluginItem[],
+    presets,
+    parserPlugins: [
+      ...BASE_PARSER_PLUGINS,
+      'typescript' as const,
+      ...userParserPlugins,
+    ],
+  };
+
+  // V2-addon `.js` with precompileTemplate calls: template-compilation only.
+  const precompiledTemplatePlugins: PluginItem[] = [
+    [templateCompilation as PluginItem, templateCompilationOpts],
+  ];
+
+  async function compile(
+    source: string,
+    opts: CompileFileOptions,
+  ): Promise<CompileResult | null> {
+    const sourceMaps = opts.sourceMaps ?? true;
+
+    if (opts.kind === 'precompiled-template') {
+      const result = await transformAsync(source, {
+        filename: opts.filename,
+        babelrc: false,
+        configFile: false,
+        plugins: precompiledTemplatePlugins,
+        parserOpts: { sourceType: 'module' },
+        sourceMaps,
+      });
+      if (!result?.code) return null;
+      return { code: result.code, map: result.map ?? undefined };
+    }
+
+    // .gjs / .gts: content-tag preprocessing, then babel.
+    const preResult = preprocessor.process(source, {
+      filename: opts.filename,
+    }) as string | { code: string };
+    const preprocessed =
+      typeof preResult === 'string' ? preResult : preResult.code;
+
+    const cfg = opts.kind === 'gts' ? gtsConfig : gjsConfig;
+
+    const result = await transformAsync(preprocessed, {
+      filename: opts.filename,
+      babelrc: false,
+      configFile: false,
+      plugins: cfg.plugins,
+      presets: cfg.presets,
+      parserOpts: {
+        sourceType: 'module',
+        plugins: cfg.parserPlugins,
+      },
+      sourceMaps,
+    });
+
+    if (!result?.code) return null;
+    return { code: result.code, map: result.map ?? undefined };
+  }
+
+  return { compile };
+}
+
+export type { PluginItem, ParserOptions } from '@babel/core';

--- a/ember-live-compiler/src/create-owner.ts
+++ b/ember-live-compiler/src/create-owner.ts
@@ -1,0 +1,39 @@
+/**
+ * A minimal Ember-compatible owner backed by a simple `Map`.
+ */
+export interface EmberOwner {
+  /** Register a pre-built instance under a full name (e.g. `'service:greeting'`). */
+  register(fullName: string, instance: unknown): void;
+  /** Look up a previously registered instance. */
+  lookup(fullName: string): unknown;
+}
+
+/**
+ * Create a minimal Ember-compatible "owner" backed by a simple Map.
+ *
+ * A full Ember app uses an `ApplicationInstance` as the owner, but for
+ * standalone `renderComponent` usage this lightweight implementation is
+ * enough to satisfy `getOwner(this).lookup(...)` and the `@service`
+ * decorator.
+ *
+ * @example
+ * ```ts
+ * import { createOwner } from 'ember-live-compiler';
+ *
+ * const owner = createOwner();
+ * owner.register('service:greeting', new GreetingService());
+ * ```
+ */
+export function createOwner(): EmberOwner {
+  const services = new Map<string, unknown>();
+
+  return {
+    register(fullName: string, instance: unknown) {
+      services.set(fullName, instance);
+    },
+
+    lookup(fullName: string) {
+      return services.get(fullName);
+    },
+  };
+}

--- a/ember-live-compiler/src/index.ts
+++ b/ember-live-compiler/src/index.ts
@@ -1,0 +1,23 @@
+/**
+ * `ember-live-compiler` — Node / build-time entry point.
+ *
+ * Hosts {@link createNodeCompiler}, the Babel + content-tag pipeline that
+ * turns `.gjs` / `.gts` source (and V2-addon `precompileTemplate()` `.js`)
+ * into compiled JavaScript modules. Bundler plugins wrap this with their
+ * own file-id sniffing and module-resolution logic.
+ *
+ * Also re-exports the small runtime owner helper so consumers can depend
+ * on a single package for both build-time and minimal runtime needs.
+ */
+
+export { createNodeCompiler } from './compile.node.js';
+export { createOwner } from './create-owner.js';
+
+export type {
+  NodeCompiler,
+  NodeCompilerOptions,
+  CompileFileOptions,
+  CompileKind,
+  CompileResult,
+} from './compile.node.js';
+export type { EmberOwner } from './create-owner.js';

--- a/ember-live-compiler/src/resolver/ember-modules.ts
+++ b/ember-live-compiler/src/resolver/ember-modules.ts
@@ -1,0 +1,18 @@
+/**
+ * Bare-specifier prefixes that should be resolved into `ember-source`'s
+ * `dist/packages/` tree.
+ *
+ * E.g. `@ember/renderer` → `<ember-source>/dist/packages/@ember/renderer/index.js`.
+ */
+export const EMBER_PACKAGE_PREFIXES = ['@ember/', '@glimmer/'] as const;
+
+/**
+ * Returns `true` when the given bare specifier belongs to one of the
+ * Ember-owned package namespaces ({@link EMBER_PACKAGE_PREFIXES}).
+ */
+export function isEmberSpecifier(id: string): boolean {
+  for (const prefix of EMBER_PACKAGE_PREFIXES) {
+    if (id.startsWith(prefix)) return true;
+  }
+  return false;
+}

--- a/ember-live-compiler/src/resolver/index.ts
+++ b/ember-live-compiler/src/resolver/index.ts
@@ -1,0 +1,14 @@
+/**
+ * `ember-live-compiler/resolver` — pure bundler-helper utilities.
+ *
+ * These helpers contain no DOM, no Babel, and no Node-only APIs, so they
+ * are safe to import from any environment (build tools, runtime bundlers,
+ * tests).
+ */
+
+export {
+  EMBROIDER_MACROS_VIRTUAL_ID,
+  EMBROIDER_MACROS_SHIM_SOURCE,
+} from './macros-shim.js';
+
+export { EMBER_PACKAGE_PREFIXES, isEmberSpecifier } from './ember-modules.js';

--- a/ember-live-compiler/src/resolver/macros-shim.ts
+++ b/ember-live-compiler/src/resolver/macros-shim.ts
@@ -1,0 +1,31 @@
+/**
+ * Runtime shim for `@embroider/macros`.
+ *
+ * `ember-source`'s ESM modules import compile-time helpers from
+ * `@embroider/macros` (`isDevelopingApp`, `macroCondition`, …). Outside of
+ * the Embroider build pipeline those imports have no implementation, so
+ * any bundler that wants to serve ember-source ESM directly must supply
+ * runtime versions instead.
+ *
+ * Bundler plugins typically:
+ *   1. resolve `@embroider/macros` to {@link EMBROIDER_MACROS_VIRTUAL_ID}
+ *   2. load that id and return {@link EMBROIDER_MACROS_SHIM_SOURCE}
+ *
+ * The `\0`-prefixed id follows the Rollup / Vite convention for virtual
+ * modules. Consumers using other bundlers may pick any unique id.
+ */
+
+export const EMBROIDER_MACROS_VIRTUAL_ID = '\0embroider-macros-shim';
+
+export const EMBROIDER_MACROS_SHIM_SOURCE = `
+export function isDevelopingApp() { return true; }
+export function isTesting() { return false; }
+export function macroCondition(condition) { return condition; }
+export function dependencySatisfies() { return true; }
+export function getOwnConfig() { return {}; }
+export function getConfig() { return {}; }
+export function importSync(specifier) {
+  throw new Error('[embroider-macros shim] importSync is not supported at runtime: ' + specifier);
+}
+export function getGlobalConfig() { return { isDevelopingApp: true, isTesting: false }; }
+`;

--- a/ember-live-compiler/src/runtime/ember-renderer.d.ts
+++ b/ember-live-compiler/src/runtime/ember-renderer.d.ts
@@ -1,0 +1,14 @@
+/**
+ * Ambient declaration for `@ember/renderer`.
+ *
+ * The module is a virtual subpath provided by `ember-source >= 6.8` in the
+ * consumer app — it has no on-disk file for the library's type-checker to
+ * find. We declare a minimal shape here so `tsc` is happy while the actual
+ * implementation is resolved by the host bundler (Vite plugin) at runtime.
+ */
+declare module '@ember/renderer' {
+  export function renderComponent(
+    component: unknown,
+    options: { into: Element; owner?: object },
+  ): { destroy?: () => void } | undefined;
+}

--- a/ember-live-compiler/src/runtime/index.ts
+++ b/ember-live-compiler/src/runtime/index.ts
@@ -1,13 +1,17 @@
 /**
- * `ember-live-compiler/runtime` — browser entry point.
+ * `ember-live-compiler/runtime` — browser-safe entry point.
  *
- * Will host `compile()` (lazy `@babel/standalone` + content-tag wasm) and
- * `render()` (mount a compiled module into a DOM element with an Ember owner).
+ * Exports:
+ * - `createOwner` — Map-backed Ember owner factory (no DOM, no Babel).
+ * - `render`     — mount a component module into a DOM element via
+ *                  `@ember/renderer` (lazy-imported).
  *
- * Today it only re-exports the owner helper so the subpath export is real
- * and importable from day one.
+ * Future work: `compile()` (lazy `@babel/standalone` + content-tag wasm) so
+ * browsers can also do source → component without a build step.
  */
 
 export { createOwner } from '../create-owner.js';
+export { render } from './render.js';
 
 export type { EmberOwner } from '../create-owner.js';
+export type { Mount, RenderOptions } from './render.js';

--- a/ember-live-compiler/src/runtime/index.ts
+++ b/ember-live-compiler/src/runtime/index.ts
@@ -1,0 +1,13 @@
+/**
+ * `ember-live-compiler/runtime` — browser entry point.
+ *
+ * Will host `compile()` (lazy `@babel/standalone` + content-tag wasm) and
+ * `render()` (mount a compiled module into a DOM element with an Ember owner).
+ *
+ * Today it only re-exports the owner helper so the subpath export is real
+ * and importable from day one.
+ */
+
+export { createOwner } from '../create-owner.js';
+
+export type { EmberOwner } from '../create-owner.js';

--- a/ember-live-compiler/src/runtime/render.ts
+++ b/ember-live-compiler/src/runtime/render.ts
@@ -22,23 +22,16 @@ export interface RenderOptions {
   owner?: EmberOwner | object;
 }
 
-type RendererModule = {
-  renderComponent: (
-    component: unknown,
-    options: { into: Element; owner?: object },
-  ) => { destroy?: () => void } | undefined;
-};
+type RendererModule = typeof import('@ember/renderer');
 
 let rendererPromise: Promise<RendererModule> | undefined;
 function loadRenderer(): Promise<RendererModule> {
-  // `@ember/renderer` is a virtual subpath provided by ember-source 6.8+ in
-  // the consumer app. It does not exist on disk during library type-checking,
-  // so we route the import through a variable to keep TS from trying to
-  // resolve it. The actual resolution happens in the browser at runtime.
-  const specifier = '@ember/renderer';
-  rendererPromise ??= import(
-    /* @vite-ignore */ specifier
-  ) as Promise<RendererModule>;
+  // `@ember/renderer` is a virtual subpath provided by ember-source 6.8+ and
+  // resolved by the host bundler (vite-plugin-ember maps `@ember/*` onto
+  // `ember-source/dist/...`). The literal specifier is intentional so Vite's
+  // import analyzer can see it and pre-bundle the module — wrapping it in a
+  // variable would ship the bare specifier to the browser unresolved.
+  rendererPromise ??= import('@ember/renderer');
   return rendererPromise;
 }
 

--- a/ember-live-compiler/src/runtime/render.ts
+++ b/ember-live-compiler/src/runtime/render.ts
@@ -1,0 +1,69 @@
+/**
+ * `ember-live-compiler/runtime` — browser-safe `render()`.
+ *
+ * Thin wrapper around `@ember/renderer` (Ember 6.8+) that:
+ * - lazily imports the renderer so apps that never call `render()` don't pay
+ *   the import cost,
+ * - unwraps a module's `default` export when callers pass an ESM namespace
+ *   object instead of a component class,
+ * - normalizes the disposer into the documented `Mount` shape.
+ */
+
+import type { EmberOwner } from '../create-owner.js';
+
+export interface Mount {
+  destroy(): void;
+}
+
+export interface RenderOptions {
+  /** DOM element to mount into. */
+  into: Element;
+  /** Optional Ember owner. Recommended for services / DI. */
+  owner?: EmberOwner | object;
+}
+
+type RendererModule = {
+  renderComponent: (
+    component: unknown,
+    options: { into: Element; owner?: object },
+  ) => { destroy?: () => void } | undefined;
+};
+
+let rendererPromise: Promise<RendererModule> | undefined;
+function loadRenderer(): Promise<RendererModule> {
+  // `@ember/renderer` is a virtual subpath provided by ember-source 6.8+ in
+  // the consumer app. It does not exist on disk during library type-checking,
+  // so we route the import through a variable to keep TS from trying to
+  // resolve it. The actual resolution happens in the browser at runtime.
+  const specifier = '@ember/renderer';
+  rendererPromise ??= import(
+    /* @vite-ignore */ specifier
+  ) as Promise<RendererModule>;
+  return rendererPromise;
+}
+
+/**
+ * Mount an Ember component (or an ESM module whose `default` export is one)
+ * into a DOM element. Returns a `Mount` whose `destroy()` tears it down.
+ */
+export async function render(
+  component: unknown,
+  options: RenderOptions,
+): Promise<Mount> {
+  const { renderComponent } = await loadRenderer();
+  const target =
+    component && typeof component === 'object' && 'default' in component
+      ? (component as { default: unknown }).default
+      : component;
+
+  const disposer = renderComponent(target, {
+    into: options.into,
+    ...(options.owner ? { owner: options.owner } : {}),
+  });
+
+  return {
+    destroy() {
+      disposer?.destroy?.();
+    },
+  };
+}

--- a/ember-live-compiler/tsconfig.json
+++ b/ember-live-compiler/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "outDir": "dist",
+    "rootDir": "./src",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "types": ["node"]
+  },
+  "include": ["src"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -124,18 +124,6 @@ importers:
 
   vite-plugin-ember:
     dependencies:
-      '@babel/core':
-        specifier: ^7.29.0
-        version: 7.29.0
-      '@babel/plugin-transform-typescript':
-        specifier: ^7.28.6
-        version: 7.28.6(@babel/core@7.29.0)
-      babel-plugin-ember-template-compilation:
-        specifier: ^4.0.0
-        version: 4.0.0
-      content-tag:
-        specifier: ^4.2.0
-        version: 4.2.0
       decorator-transforms:
         specifier: ^2.3.2
         version: 2.3.2(@babel/core@7.29.0)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -76,6 +76,52 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.9.1)
 
+  ember-live-compiler:
+    dependencies:
+      '@babel/core':
+        specifier: ^7.29.0
+        version: 7.29.0
+      '@babel/plugin-transform-typescript':
+        specifier: ^7.28.6
+        version: 7.28.6(@babel/core@7.29.0)
+      babel-plugin-ember-template-compilation:
+        specifier: ^4.0.0
+        version: 4.0.0
+      content-tag:
+        specifier: ^4.2.0
+        version: 4.2.0
+      decorator-transforms:
+        specifier: ^2.3.2
+        version: 2.3.2(@babel/core@7.29.0)
+    devDependencies:
+      '@eslint/js':
+        specifier: ^10.0.1
+        version: 10.0.1(eslint@10.4.0)
+      '@types/babel__core':
+        specifier: ^7.20.5
+        version: 7.20.5
+      '@types/node':
+        specifier: ^25.9.1
+        version: 25.9.1
+      concurrently:
+        specifier: ^9.2.1
+        version: 9.2.1
+      eslint:
+        specifier: ^10.4.0
+        version: 10.4.0
+      eslint-config-prettier:
+        specifier: ^10.1.8
+        version: 10.1.8(eslint@10.4.0)
+      globals:
+        specifier: ^17.6.0
+        version: 17.6.0
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+      typescript-eslint:
+        specifier: ^8.59.4
+        version: 8.59.4(eslint@10.4.0)(typescript@6.0.3)
+
   vite-plugin-ember:
     dependencies:
       '@babel/core':
@@ -93,6 +139,9 @@ importers:
       decorator-transforms:
         specifier: ^2.3.2
         version: 2.3.2(@babel/core@7.29.0)
+      ember-live-compiler:
+        specifier: workspace:*
+        version: link:../ember-live-compiler
     devDependencies:
       '@eslint/js':
         specifier: ^10.0.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -12,6 +12,7 @@ peerDependencyRules:
     - search-insights
 
 packages:
+  - ember-live-compiler
   - vite-plugin-ember
   - docs
 

--- a/vite-plugin-ember/package.json
+++ b/vite-plugin-ember/package.json
@@ -74,12 +74,8 @@
     "format:check": "prettier . --cache --check"
   },
   "dependencies": {
-    "@babel/core": "^7.29.0",
-    "@babel/plugin-transform-typescript": "^7.28.6",
-    "babel-plugin-ember-template-compilation": "^4.0.0",
-    "content-tag": "^4.2.0",
-    "ember-live-compiler": "workspace:*",
-    "decorator-transforms": "^2.3.2"
+    "decorator-transforms": "^2.3.2",
+    "ember-live-compiler": "workspace:*"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",

--- a/vite-plugin-ember/src/index.ts
+++ b/vite-plugin-ember/src/index.ts
@@ -1,9 +1,14 @@
-import templateCompilation from 'babel-plugin-ember-template-compilation';
-import { transformAsync } from '@babel/core';
-import { Preprocessor } from 'content-tag';
 import { createRequire } from 'node:module';
 import { existsSync } from 'node:fs';
 
+import { createNodeCompiler } from 'ember-live-compiler';
+import {
+  EMBROIDER_MACROS_VIRTUAL_ID,
+  EMBROIDER_MACROS_SHIM_SOURCE,
+  EMBER_PACKAGE_PREFIXES,
+} from 'ember-live-compiler/resolver';
+
+import type { NodeCompiler } from 'ember-live-compiler';
 import type { ParserOptions, PluginItem } from '@babel/core';
 import type { Plugin, Rollup } from 'vite';
 
@@ -24,33 +29,6 @@ function errorCode(err: unknown): string | undefined {
 
 // ── Virtual-module helpers (for inline markdown demos) ──────────────────
 const PUBLIC_PREFIX = 'virtual:ember-demo-';
-
-/**
- * Virtual module ID for the @embroider/macros runtime shim.
- * ember-source's ESM modules import from @embroider/macros and call compile-time
- * functions like isDevelopingApp(). Outside of the Ember build pipeline these need
- * runtime implementations instead of throwing.
- */
-const EMBROIDER_MACROS_ID = '\0embroider-macros-shim';
-const EMBROIDER_MACROS_CODE = `
-export function isDevelopingApp() { return true; }
-export function isTesting() { return false; }
-export function macroCondition(condition) { return condition; }
-export function dependencySatisfies() { return true; }
-export function getOwnConfig() { return {}; }
-export function getConfig() { return {}; }
-export function importSync(specifier) {
-  throw new Error('[embroider-macros shim] importSync is not supported at runtime: ' + specifier);
-}
-export function getGlobalConfig() { return { isDevelopingApp: true, isTesting: false }; }
-`;
-
-/**
- * Bare-specifier prefixes that should be resolved into ember-source's
- * dist/packages tree.  E.g. `@ember/renderer` →
- * `<ember-source>/dist/packages/@ember/renderer/index.js`
- */
-const EMBER_PACKAGE_PREFIXES = ['@ember/', '@glimmer/'];
 
 export interface VitePluginEmberOptions {
   /**
@@ -150,8 +128,6 @@ export default function vitePluginEmber(
   options: VitePluginEmberOptions = {},
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
 ): any {
-  const preprocessor = new Preprocessor();
-
   // Locate ember-source's dist/packages directory on disk
   let emberSourcePackagesDir: string | undefined;
   // Preloaded template compiler (only available when the legacy CJS bundle
@@ -171,81 +147,20 @@ export default function vitePluginEmber(
   const resolveCache = new Map<string, string | null>();
   let decoratorRuntimePath: string | undefined;
 
-  // ── Pre-built babel configs (allocated once, cloned per-transform) ──
-  type ParserPluginList = NonNullable<ParserOptions['plugins']>;
-  let babelConfigGJS: {
-    plugins: PluginItem[];
-    presets: PluginItem[];
-    parserPlugins: ParserPluginList;
-  };
-  let babelConfigGTS: {
-    plugins: PluginItem[];
-    presets: PluginItem[];
-    parserPlugins: ParserPluginList;
-  };
+  // Compile pipeline (built once `configResolved` has located the template
+  // compiler so the engine sees the right `compiler` / `compilerPath`).
+  let compiler: NodeCompiler | undefined;
 
-  // Prefer a preloaded compiler when present (fast path, no async resolve).
-  // Otherwise hand a path off to babel-plugin-ember-template-compilation —
-  // when neither `compiler` nor `compilerPath` is provided it will try the
-  // Ember 7+ ESM path first and fall back to the legacy CJS bundle.
-  function getTemplateCompilationOpts(): Record<string, unknown> {
-    if (compilerObj) return { compiler: compilerObj };
-    if (resolvedCompilerPath) return { compilerPath: resolvedCompilerPath };
-    return {};
-  }
-
-  function buildBabelConfigs() {
-    const baseParserPlugins: ParserPluginList = [
-      'classProperties',
-      'classPrivateProperties',
-      'classPrivateMethods',
-    ];
-
-    // Normalize `babelPlugins` (array | { before, after }) into ordered slots
-    // around the built-ins.
-    let userBefore: PluginItem[] = [];
-    let userAfter: PluginItem[] = [];
-    if (Array.isArray(options.babelPlugins)) {
-      userAfter = options.babelPlugins;
-    } else if (options.babelPlugins) {
-      userBefore = options.babelPlugins.before ?? [];
-      userAfter = options.babelPlugins.after ?? [];
-    }
-
-    const basePlugins: PluginItem[] = [
-      ...userBefore,
-      [templateCompilation as PluginItem, getTemplateCompilationOpts()],
-      [
-        'module:decorator-transforms',
-        { runtime: { import: 'decorator-transforms/runtime' } },
-      ],
-      ...userAfter,
-    ];
-
-    const presets: PluginItem[] = [...(options.babelPresets ?? [])];
-    const userParserPlugins = options.parserPlugins ?? [];
-
-    babelConfigGJS = {
-      plugins: basePlugins,
-      presets,
-      parserPlugins: [...baseParserPlugins, ...userParserPlugins],
-    };
-
-    babelConfigGTS = {
-      plugins: [
-        ...basePlugins,
-        [
-          '@babel/plugin-transform-typescript',
-          {
-            allExtensions: true,
-            onlyRemoveTypeImports: true,
-            allowDeclareFields: true,
-          },
-        ],
-      ],
-      presets,
-      parserPlugins: [...baseParserPlugins, 'typescript', ...userParserPlugins],
-    };
+  function buildCompiler() {
+    compiler = createNodeCompiler({
+      templateCompiler: {
+        compiler: compilerObj,
+        compilerPath: resolvedCompilerPath,
+      },
+      babelPlugins: options.babelPlugins,
+      babelPresets: options.babelPresets,
+      parserPlugins: options.parserPlugins,
+    });
   }
 
   /**
@@ -471,7 +386,7 @@ export default function vitePluginEmber(
         // not installed
       }
 
-      buildBabelConfigs();
+      buildCompiler();
     },
 
     /* ─── serve virtual modules before VitePress catches them ─────── */
@@ -507,7 +422,7 @@ export default function vitePluginEmber(
       if (id.startsWith('\0')) return null;
 
       // Shim @embroider/macros with runtime implementations
-      if (id === '@embroider/macros') return EMBROIDER_MACROS_ID;
+      if (id === '@embroider/macros') return EMBROIDER_MACROS_VIRTUAL_ID;
 
       // Resolve decorator-transforms runtime (pre-cached ESM path)
       if (id === 'decorator-transforms/runtime') {
@@ -538,7 +453,8 @@ export default function vitePluginEmber(
 
     /* ─── load virtual module source from registry ────────────────── */
     load(id) {
-      if (id === EMBROIDER_MACROS_ID) return EMBROIDER_MACROS_CODE;
+      if (id === EMBROIDER_MACROS_VIRTUAL_ID)
+        return EMBROIDER_MACROS_SHIM_SOURCE;
       if (!id.startsWith(PUBLIC_PREFIX)) return null;
       return demoRegistry.get(id) ?? null;
     },
@@ -570,6 +486,8 @@ export default function vitePluginEmber(
 
     /* ─── transform .gjs / .gts / V2-addon .js files ────────────── */
     async transform(code, id) {
+      if (!compiler) return null;
+
       // Skip ?raw imports — let Vite serve the original source text
       if (id.includes('?raw') || id.includes('&raw')) return null;
 
@@ -585,54 +503,29 @@ export default function vitePluginEmber(
       // cheap string check and run only the template-compilation
       // Babel plugin (no content-tag or decorator transforms needed).
       if (isJS && code.includes('precompileTemplate')) {
-        const result = await transformAsync(code, {
+        const result = await compiler.compile(code, {
           filename: bareId,
-          babelrc: false,
-          configFile: false,
-          plugins: [
-            [templateCompilation as PluginItem, getTemplateCompilationOpts()],
-          ],
-          parserOpts: { sourceType: 'module' },
-          sourceMaps: true,
+          kind: 'precompiled-template',
         });
-        if (!result?.code) return null;
+        if (!result) return null;
         return { code: result.code, map: result.map as Rollup.SourceMapInput };
       }
 
       if (!isGJS && !isGTS) return null;
 
-      // ── Step 1: content-tag preprocessing ──
-      let preprocessed: string;
       try {
-        const result = preprocessor.process(code, { filename: bareId }) as
-          | string
-          | { code: string };
-        preprocessed = typeof result === 'string' ? result : result.code;
+        const result = await compiler.compile(code, {
+          filename: bareId,
+          kind: isGTS ? 'gts' : 'gjs',
+        });
+        if (!result) return null;
+        return { code: result.code, map: result.map as Rollup.SourceMapInput };
       } catch (err) {
         this.error(
-          `[vite-plugin-ember] content-tag failed for ${bareId}: ${errorMessage(err)}`,
+          `[vite-plugin-ember] compile failed for ${bareId}: ${errorMessage(err)}`,
         );
         return null;
       }
-
-      // ── Step 2: Babel (template compilation + decorators + optional TS) ──
-      const cfg = isGTS ? babelConfigGTS : babelConfigGJS;
-
-      const result = await transformAsync(preprocessed, {
-        filename: bareId,
-        babelrc: false,
-        configFile: false,
-        plugins: cfg.plugins,
-        presets: cfg.presets,
-        parserOpts: {
-          sourceType: 'module',
-          plugins: cfg.parserPlugins,
-        },
-        sourceMaps: true,
-      });
-
-      if (!result?.code) return null;
-      return { code: result.code, map: result.map as Rollup.SourceMapInput };
     },
   } satisfies Plugin;
 }

--- a/vite-plugin-ember/src/vitepress/code-preview.ts
+++ b/vite-plugin-ember/src/vitepress/code-preview.ts
@@ -6,8 +6,10 @@ import {
   inject,
   h,
 } from 'vue';
+import { render } from 'ember-live-compiler/runtime';
 import { EMBER_OWNER_KEY } from './constants.js';
 
+import type { Mount } from 'ember-live-compiler/runtime';
 import type { PropType } from 'vue';
 
 // Inlined to avoid a top-level static import from `vitepress`. The `vitepress`
@@ -55,34 +57,19 @@ export default defineComponent({
     );
     const mountEl = ref<HTMLDivElement | null>(null);
     const error = ref<string | null>(null);
-    let cleanup: undefined | { destroy?: () => void };
-
-    type RendererModule = {
-      renderComponent: (
-        component: unknown,
-        options: { into: Element; owner?: object },
-      ) => { destroy?: () => void };
-    };
-
-    let rendererPromise: Promise<RendererModule> | undefined;
-    function getRenderer() {
-      rendererPromise ??= import('@ember/renderer') as Promise<RendererModule>;
-      return rendererPromise!;
-    }
+    let mount: Mount | undefined;
 
     onMounted(async () => {
       ensureStyle();
       if (!inBrowser || !mountEl.value) return;
 
       try {
-        const [mod, { renderComponent }] = await Promise.all([
-          props.loader ? props.loader() : import(/* @vite-ignore */ props.src!),
-          getRenderer(),
-        ]);
+        const mod = await (props.loader
+          ? props.loader()
+          : import(/* @vite-ignore */ props.src!));
 
-        const component = mod?.default ?? mod;
         const owner = props.owner ?? injectedOwner;
-        cleanup = renderComponent(component, {
+        mount = await render(mod, {
           into: mountEl.value,
           ...(owner ? { owner } : {}),
         });
@@ -93,8 +80,8 @@ export default defineComponent({
     });
 
     onBeforeUnmount(() => {
-      cleanup?.destroy?.();
-      cleanup = undefined;
+      mount?.destroy();
+      mount = undefined;
     });
 
     return () => {

--- a/vite-plugin-ember/src/vitepress/create-owner.ts
+++ b/vite-plugin-ember/src/vitepress/create-owner.ts
@@ -1,39 +1,7 @@
 /**
- * A minimal Ember-compatible owner backed by a simple `Map`.
+ * Re-exported from `ember-live-compiler/runtime` (the browser-safe subpath
+ * that does NOT pull in the Node Babel pipeline) to preserve the existing
+ * `vite-plugin-ember/owner` subpath import for downstream consumers.
  */
-export interface EmberOwner {
-  /** Register a pre-built instance under a full name (e.g. `'service:greeting'`). */
-  register(fullName: string, instance: unknown): void;
-  /** Look up a previously registered instance. */
-  lookup(fullName: string): unknown;
-}
-
-/**
- * Create a minimal Ember-compatible "owner" backed by a simple Map.
- *
- * A full Ember app uses an `ApplicationInstance` as the owner, but for
- * standalone `renderComponent` usage this lightweight implementation is
- * enough to satisfy `getOwner(this).lookup(...)` and the `@service`
- * decorator.
- *
- * @example
- * ```ts
- * import { createOwner } from 'vite-plugin-ember/owner';
- *
- * const owner = createOwner();
- * owner.register('service:greeting', new GreetingService());
- * ```
- */
-export function createOwner(): EmberOwner {
-  const services = new Map<string, unknown>();
-
-  return {
-    register(fullName: string, instance: unknown) {
-      services.set(fullName, instance);
-    },
-
-    lookup(fullName: string) {
-      return services.get(fullName);
-    },
-  };
-}
+export { createOwner } from 'ember-live-compiler/runtime';
+export type { EmberOwner } from 'ember-live-compiler/runtime';


### PR DESCRIPTION
Introduce new private workspace package 'ember-live-compiler' housing the reusable .gjs/.gts/precompiled-template pipeline (createNodeCompiler), Ember owner factory, and resolver helpers (macros shim, ember package prefix check).

- New package with subpath exports: '.', './runtime', './resolver'
- vite-plugin-ember now consumes the engine via workspace:* and delegates transform() to compiler.compile(); VitePress shim imports owner from 'ember-live-compiler/runtime' to keep @babel/core out of the browser bundle
- CI workflows updated to run pnpm build/lint workspace-wide; deploy-docs uses 'pnpm -F vite-plugin-ember... build' to pull workspace deps
- Engine stays private (0.0.1 scaffold); release-plan untouched