### PR TITLE
feat(ember-live-compiler): publish as 0.1.0 (un-private)

### DIFF
--- a/ember-live-compiler/package.json
+++ b/ember-live-compiler/package.json
@@ -1,20 +1,7 @@
 {
   "name": "ember-live-compiler",
-  "version": "0.0.1",
-  "private": true,
+  "version": "0.1.0",
   "description": "Bundler-agnostic engine for compiling and rendering .gjs/.gts Ember components — the core that powers live Ember demos in VitePress, Docusaurus, Storybook, Backstage TechDocs, kolay, and more.",
-  "license": "MIT",
-  "type": "module",
-  "author": "Alexey Kulakov",
-  "homepage": "https://github.com/aklkv/vite-plugin-ember/tree/main/ember-live-compiler#readme",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/aklkv/vite-plugin-ember.git",
-    "directory": "ember-live-compiler"
-  },
-  "bugs": {
-    "url": "https://github.com/aklkv/vite-plugin-ember/issues"
-  },
   "keywords": [
     "ember",
     "emberjs",
@@ -27,9 +14,19 @@
     "live-preview",
     "documentation"
   ],
+  "homepage": "https://github.com/aklkv/vite-plugin-ember/tree/main/ember-live-compiler#readme",
+  "bugs": {
+    "url": "https://github.com/aklkv/vite-plugin-ember/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/aklkv/vite-plugin-ember.git",
+    "directory": "ember-live-compiler"
+  },
+  "license": "MIT",
+  "author": "Alexey Kulakov",
   "sideEffects": false,
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "type": "module",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
@@ -44,20 +41,22 @@
       "default": "./dist/resolver/index.js"
     }
   },
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "files": [
     "dist"
   ],
   "scripts": {
     "build": "tsc -p tsconfig.json",
+    "format": "prettier . --cache --write",
+    "format:check": "prettier . --cache --check",
     "lint": "concurrently 'pnpm:lint:*(!fix)' --names 'lint:'",
     "lint:fix": "concurrently 'pnpm:lint:*:fix' --names 'fix:'",
-    "lint:js": "eslint .",
-    "lint:js:fix": "eslint . --fix",
     "lint:format": "prettier . --cache --check",
     "lint:format:fix": "prettier . --cache --write",
-    "lint:types": "tsc --noEmit",
-    "format": "prettier . --cache --write",
-    "format:check": "prettier . --cache --check"
+    "lint:js": "eslint .",
+    "lint:js:fix": "eslint . --fix",
+    "lint:types": "tsc --noEmit"
   },
   "dependencies": {
     "@babel/core": "^7.29.0",
@@ -65,14 +64,6 @@
     "babel-plugin-ember-template-compilation": "^4.0.0",
     "content-tag": "^4.2.0",
     "decorator-transforms": "^2.3.2"
-  },
-  "peerDependencies": {
-    "ember-source": ">= 6.8.0"
-  },
-  "peerDependenciesMeta": {
-    "ember-source": {
-      "optional": true
-    }
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
@@ -84,5 +75,16 @@
     "globals": "^17.6.0",
     "typescript": "^6.0.3",
     "typescript-eslint": "^8.59.4"
+  },
+  "peerDependencies": {
+    "ember-source": ">= 6.8.0"
+  },
+  "peerDependenciesMeta": {
+    "ember-source": {
+      "optional": true
+    }
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }


### PR DESCRIPTION
release-plan refused to prepare a release while vite-plugin-ember had a 'workspace:*' reference to a private package:

    Error: broken "workspace:" reference to ember-live-compiler
           in vite-plugin-ember
        at publishedInterPackageDeps

Promote the engine to a real public package so release-plan can manage both packages together.

- Drop "private": true from ember-live-compiler/package.json
- Set version to 0.1.0 (initial public, pre-1.0 — API still evolving)
- Add publishConfig.access = public so unscoped publish works

.release-plan.json is regenerated by the release-plan bot on the next prepare run, so the stale 0.6.0 solution stays as-is until the bot rewrites it with both packages.