### PR TITLE
docs: split root README from vite-plugin-ember; refresh engine README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,78 @@
-vite-plugin-ember/README.md
+# Live Ember demos — engine + integrations
+
+[![CI](https://github.com/aklkv/vite-plugin-ember/actions/workflows/ci.yml/badge.svg)](https://github.com/aklkv/vite-plugin-ember/actions/workflows/ci.yml)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](./LICENSE)
+
+A monorepo for compiling and rendering live `.gjs` / `.gts` [Ember](https://emberjs.com/) components inside docs and preview tools — without standing up a full Ember app.
+
+**[View the live documentation →](https://aklkv.github.io/vite-plugin-ember/)**
+
+## Packages
+
+| Package                                        | npm                                                                                                               | What it does                                                                                                                                   |
+| ---------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| [`ember-live-compiler`](./ember-live-compiler) | [![npm](https://img.shields.io/npm/v/ember-live-compiler.svg)](https://www.npmjs.com/package/ember-live-compiler) | Bundler-agnostic engine. Node `createNodeCompiler()` (Babel + content-tag) and a browser `render()` API. Use it to build your own integration. |
+| [`vite-plugin-ember`](./vite-plugin-ember)     | [![npm](https://img.shields.io/npm/v/vite-plugin-ember.svg)](https://www.npmjs.com/package/vite-plugin-ember)     | The reference integration: Vite plugin + VitePress helpers (` ```gjs live ` fences, `<CodePreview>`, `setupEmber`).                            |
+
+The engine is designed to power live Ember demos in any docs/preview stack —
+VitePress (shipped), Docusaurus, Storybook, Backstage TechDocs,
+[kolay](https://github.com/universal-ember/kolay), `ember-cli-addon-docs`
+(planned / community).
+
+## Which package do I want?
+
+- **Writing a VitePress site and want to embed live Ember components** → use
+  [`vite-plugin-ember`](./vite-plugin-ember). The README there has the full
+  quick-start (install → configure → write a fence).
+- **Plain Vite, no VitePress** → `vite-plugin-ember` also works standalone;
+  its VitePress helpers live behind separate subpath exports you can ignore.
+- **Building a plugin for a different bundler or docs tool** → depend on
+  [`ember-live-compiler`](./ember-live-compiler) and wrap its
+  `createNodeCompiler()` / `render()` with the bundler-specific glue.
+- **You want a full Ember app on Vite** (replacement for `ember-cli` /
+  `@embroider/vite`) → not the goal of this project.
+
+## Repository layout
+
+```text
+├── ember-live-compiler/   # Bundler-agnostic engine (published to npm)
+│   └── src/
+│       ├── index.ts                 # Node entry — createNodeCompiler()
+│       ├── compile.node.ts          # Babel + content-tag pipeline
+│       ├── create-owner.ts          # Map-backed Ember owner
+│       ├── runtime/                 # Browser entry — render(), createOwner
+│       └── resolver/                # Pure @ember/* resolution helpers
+├── vite-plugin-ember/     # Vite plugin + VitePress helpers (published to npm)
+│   └── src/
+│       ├── index.ts                 # Vite plugin (delegates compile to engine)
+│       └── vitepress/               # CodePreview, ember-fence, setupEmber
+├── docs/                  # VitePress documentation site (uses both above)
+│   ├── demos/             # .gjs/.gts demo components
+│   └── guide/             # Documentation pages
+├── package.json           # Workspace root (private)
+└── pnpm-workspace.yaml
+```
+
+## Local development
+
+```sh
+pnpm install
+pnpm dev        # runs the VitePress docs site against the workspace packages
+pnpm build      # builds every workspace package + the docs site
+pnpm lint       # lint + format check across workspaces
+```
+
+## Requirements
+
+- Node.js ≥ 24
+- pnpm ≥ 10
+
+## Releasing
+
+Releases are managed by [`release-plan`](https://github.com/embroider-build/release-plan)
+and published via OIDC from `.github/workflows/publish.yml`. See
+[RELEASE.md](./RELEASE.md) for the contributor flow.
+
+## License
+
+[MIT](./LICENSE)

--- a/ember-live-compiler/README.md
+++ b/ember-live-compiler/README.md
@@ -1,25 +1,114 @@
 # ember-live-compiler
 
-> **Status: 0.0.1 — scaffold only.** The public surface is being extracted from
-> [`vite-plugin-ember`](../vite-plugin-ember). Today only `createOwner` is
-> implemented; the build-time and runtime compile pipelines land in 0.1.
+> Bundler-agnostic engine for compiling and rendering `.gjs` / `.gts` Ember
+> components. Extracted from [`vite-plugin-ember`](../vite-plugin-ember) so the
+> same core can power live Ember demos in any docs/preview stack.
 
-A bundler-agnostic engine for compiling and rendering `.gjs` / `.gts` Ember
-components. It will be the shared core that powers live Ember demos in:
+[![npm](https://img.shields.io/npm/v/ember-live-compiler.svg)](https://www.npmjs.com/package/ember-live-compiler)
+[![license](https://img.shields.io/npm/l/ember-live-compiler.svg)](./LICENSE)
 
-- VitePress (via `vite-plugin-ember`)
-- Docusaurus (via `docusaurus-plugin-ember`, planned)
-- Storybook (after [storybookjs/storybook#33048](https://github.com/storybookjs/storybook/pull/33048))
-- Backstage TechDocs (via a runtime-only addon, planned)
-- [kolay](https://github.com/universal-ember/kolay) and `ember-cli-addon-docs` (as a shared dependency, planned)
+## Why
+
+Every "live Ember demo" tool needs the same two pieces: a Babel + content-tag
+pipeline at build time, and a minimal owner + renderer at runtime. Until now
+those lived inside `vite-plugin-ember`. This package lifts them out so the
+ecosystem can share one implementation:
+
+- VitePress — via [`vite-plugin-ember`](../vite-plugin-ember)
+- Docusaurus — via `docusaurus-plugin-ember` (planned)
+- Storybook — after [storybookjs/storybook#33048](https://github.com/storybookjs/storybook/pull/33048)
+- Backstage TechDocs — runtime-only addon (planned)
+- [kolay](https://github.com/universal-ember/kolay), `ember-cli-addon-docs` — as a shared dependency (planned)
+
+## Install
+
+```sh
+npm install ember-live-compiler
+# peer (optional, only needed for runtime/render):
+npm install ember-source
+```
+
+`ember-source >= 6.8.0` is declared as an optional peer — required only if you
+call `render()`, since it dynamically imports `@ember/renderer`.
 
 ## Subpath exports
 
-| Import                         | Environment | Purpose                                               |
-| ------------------------------ | ----------- | ----------------------------------------------------- |
-| `ember-live-compiler`          | Node        | Build-time `compile()` for bundler plugins.           |
-| `ember-live-compiler/runtime`  | Browser     | In-browser `compile()` + `render()`.                  |
-| `ember-live-compiler/resolver` | Both        | Pure helpers for resolving `@ember/*` / `@glimmer/*`. |
+| Import                         | Environment   | Purpose                                                        |
+| ------------------------------ | ------------- | -------------------------------------------------------------- |
+| `ember-live-compiler`          | Node          | Build-time `createNodeCompiler()` — Babel + content-tag.       |
+| `ember-live-compiler/runtime`  | Browser       | `render()` + `createOwner()` for mounting compiled components. |
+| `ember-live-compiler/resolver` | Node, Browser | Pure helpers for resolving `@ember/*` / `@glimmer/*`.          |
+
+## Node — build-time compile
+
+```ts
+import { createNodeCompiler } from 'ember-live-compiler';
+
+const compiler = createNodeCompiler({
+  // Optional: pass a pre-loaded ember-template-compiler, or a path to one
+  templateCompiler: {
+    compilerPath: 'ember-source/dist/ember-template-compiler.js',
+  },
+  babelPlugins: [],
+  babelPresets: [],
+  parserPlugins: [],
+});
+
+const { code, map } = await compiler.compile(source, {
+  filename: 'demo.gjs',
+  kind: 'gjs', // 'gjs' | 'gts' | 'precompiled-template'
+  sourceMaps: true,
+});
+```
+
+Wrap it in a Vite / Rollup / esbuild / Webpack plugin and you've got Ember SFC
+support.
+
+## Browser — render
+
+```ts
+import { render } from 'ember-live-compiler/runtime';
+import * as DemoModule from './demo.gjs';
+
+const mount = await render(DemoModule, {
+  into: document.getElementById('preview')!,
+});
+
+// later
+mount.destroy();
+```
+
+`render()` lazily imports `@ember/renderer` (Ember 6.8+) so apps that never
+call it don't pay the import cost. The host bundler must be able to resolve
+`@ember/*` specifiers — `vite-plugin-ember`'s `resolveId` hook and
+`ssr.noExternal` rule already handle this; equivalent wiring is needed for
+other bundlers.
+
+## Resolver helpers
+
+For bundler authors who need to wire up `@ember/*` resolution themselves:
+
+```ts
+import {
+  EMBER_PACKAGE_PREFIXES,
+  EMBROIDER_MACROS_VIRTUAL_ID,
+  EMBROIDER_MACROS_SHIM_SOURCE,
+  isEmberSpecifier,
+} from 'ember-live-compiler/resolver';
+```
+
+Pure, bundler-free. No I/O, no Babel, safe to import from anywhere.
+
+## Status
+
+`0.1.x` — public but pre-stable. The Node compile pipeline and runtime
+`render()` are exercised in production by `vite-plugin-ember`'s VitePress
+docs. Planned for upcoming minors:
+
+- `compile()` in `runtime` (lazy `@babel/standalone` + content-tag wasm) for
+  fully in-browser source → component.
+- Stable 1.0 once at least one additional bundler integration ships against
+  the engine.
 
 ## License
 


### PR DESCRIPTION
The root README.md was a symlink to vite-plugin-ember/README.md, so the GitHub repo landing page told the whole monorepo story through one package's lens. Now that ember-live-compiler is its own published package, separate the two:

- README.md (root) — replace the symlink with a real file that frames the project as 'engine + integrations', tables both published packages with npm badges, adds a 'which package do I want?' guide, and documents the workspace layout / dev / release flow.
- ember-live-compiler/README.md — rewrite for the published 0.1.0: install, subpath exports table, Node createNodeCompiler() example, browser render() example, resolver helpers, roadmap.
- vite-plugin-ember/README.md — unchanged (it's the right package-focused content already).