### PR TITLE
chore: normalize repository.url to git+https form

### DIFF
--- a/ember-live-compiler/package.json
+++ b/ember-live-compiler/package.json
@@ -20,7 +20,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/aklkv/vite-plugin-ember.git",
+    "url": "git+https://github.com/aklkv/vite-plugin-ember.git",
     "directory": "ember-live-compiler"
   },
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "repository": {
     "type": "git",
-    "url": "https://github.com/aklkv/vite-plugin-ember.git"
+    "url": "git+https://github.com/aklkv/vite-plugin-ember.git"
   },
   "license": "MIT",
   "type": "module",

--- a/vite-plugin-ember/package.json
+++ b/vite-plugin-ember/package.json
@@ -8,7 +8,7 @@
   "homepage": "https://github.com/aklkv/vite-plugin-ember#readme",
   "repository": {
     "type": "git",
-    "url": "https://github.com/aklkv/vite-plugin-ember.git",
+    "url": "git+https://github.com/aklkv/vite-plugin-ember.git",
     "directory": "vite-plugin-ember"
   },
   "bugs": {


### PR DESCRIPTION
npm normalizes repository.url at publish time and warns when the value isn't in canonical 'git+https://...' form. Apply the prefix in all three package.json files so the warning stops appearing on publish.