### PR TITLE
feat(ember-live-compiler): add test harness using node:test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,9 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     name: Lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,3 +49,24 @@ jobs:
 
       - name: Build (all workspace packages)
         run: pnpm build
+
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: pnpm/action-setup@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: 'package.json'
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Build (all workspace packages)
+        run: pnpm build
+
+      - name: Test (all workspace packages)
+        run: pnpm test

--- a/ember-live-compiler/package.json
+++ b/ember-live-compiler/package.json
@@ -56,7 +56,8 @@
     "lint:format:fix": "prettier . --cache --write",
     "lint:js": "eslint .",
     "lint:js:fix": "eslint . --fix",
-    "lint:types": "tsc --noEmit"
+    "lint:types": "tsc --noEmit",
+    "test": "node --test --test-reporter=spec test/*.test.js"
   },
   "dependencies": {
     "@babel/core": "^7.29.0",
@@ -70,6 +71,7 @@
     "@types/babel__core": "^7.20.5",
     "@types/node": "^25.9.1",
     "concurrently": "^9.2.1",
+    "ember-source": "^7.0.0",
     "eslint": "^10.4.0",
     "eslint-config-prettier": "^10.1.8",
     "globals": "^17.6.0",

--- a/ember-live-compiler/test/compile-node.test.js
+++ b/ember-live-compiler/test/compile-node.test.js
@@ -1,0 +1,119 @@
+/**
+ * End-to-end smoke tests for the Node `createNodeCompiler()` pipeline.
+ *
+ * These tests don't pre-load a template compiler — they let
+ * `babel-plugin-ember-template-compilation` locate the installed
+ * `ember-source` on its own. That's the same path the documented "no
+ * options" usage takes, so any regression in that fallback surfaces
+ * here.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { createNodeCompiler } from '../dist/index.js';
+
+const GJS_SOURCE = `import Component from '@glimmer/component';
+
+export default class Hello extends Component {
+  name = 'world';
+
+  <template>
+    <h1>Hello {{this.name}}</h1>
+  </template>
+}
+`;
+
+const GTS_SOURCE = `import Component from '@glimmer/component';
+
+interface Args { name: string }
+
+export default class Hello extends Component<{ Args: Args }> {
+  greeting: string = 'hello';
+
+  <template>
+    <h1>{{this.greeting}} {{@name}}</h1>
+  </template>
+}
+`;
+
+const PRECOMPILED_TEMPLATE_SOURCE = `import { precompileTemplate } from '@ember/template-compilation';
+import { setComponentTemplate } from '@ember/component';
+import templateOnly from '@ember/component/template-only';
+
+export default setComponentTemplate(
+  precompileTemplate('<p>hi</p>', { strictMode: true }),
+  templateOnly(),
+);
+`;
+
+test('compiles a .gjs source into JS that references the template factory', async () => {
+  const compiler = createNodeCompiler();
+  const result = await compiler.compile(GJS_SOURCE, {
+    filename: '/virtual/Hello.gjs',
+    kind: 'gjs',
+  });
+
+  assert.ok(result, 'expected a non-null compile result');
+  assert.equal(typeof result.code, 'string');
+  // template-compilation rewrites <template> into a template factory import.
+  assert.match(
+    result.code,
+    /@ember\/template-factory/,
+    'compiled output should import the template factory',
+  );
+  // The original <template> tag must be gone.
+  assert.doesNotMatch(result.code, /<template>/);
+});
+
+test('compiles a .gts source and strips TypeScript syntax', async () => {
+  const compiler = createNodeCompiler();
+  const result = await compiler.compile(GTS_SOURCE, {
+    filename: '/virtual/Hello.gts',
+    kind: 'gts',
+  });
+
+  assert.ok(result, 'expected a non-null compile result');
+  assert.equal(typeof result.code, 'string');
+  assert.match(result.code, /@ember\/template-factory/);
+  // No leftover TS-only syntax in emitted JS.
+  assert.doesNotMatch(result.code, /interface Args/);
+  assert.doesNotMatch(result.code, /Component<\{ Args: Args \}>/);
+  assert.doesNotMatch(result.code, /greeting:\s*string\s*=/);
+});
+
+test('compiles a precompiled-template .js (no content-tag, no TS)', async () => {
+  const compiler = createNodeCompiler();
+  const result = await compiler.compile(PRECOMPILED_TEMPLATE_SOURCE, {
+    filename: '/virtual/template-only.js',
+    kind: 'precompiled-template',
+  });
+
+  assert.ok(result, 'expected a non-null compile result');
+  assert.equal(typeof result.code, 'string');
+  // precompileTemplate(...) calls are rewritten by the babel plugin.
+  assert.doesNotMatch(result.code, /precompileTemplate\(/);
+  assert.match(result.code, /@ember\/template-factory/);
+});
+
+test('honors sourceMaps: false', async () => {
+  const compiler = createNodeCompiler();
+  const result = await compiler.compile(GJS_SOURCE, {
+    filename: '/virtual/NoMap.gjs',
+    kind: 'gjs',
+    sourceMaps: false,
+  });
+
+  assert.ok(result);
+  assert.equal(result.map, undefined);
+});
+
+test('emits a source map by default', async () => {
+  const compiler = createNodeCompiler();
+  const result = await compiler.compile(GJS_SOURCE, {
+    filename: '/virtual/WithMap.gjs',
+    kind: 'gjs',
+  });
+
+  assert.ok(result);
+  assert.ok(result.map, 'expected a source map object by default');
+});

--- a/ember-live-compiler/test/compile-node.test.js
+++ b/ember-live-compiler/test/compile-node.test.js
@@ -25,9 +25,12 @@ export default class Hello extends Component {
 
 const GTS_SOURCE = `import Component from '@glimmer/component';
 
-interface Args { name: string }
+interface HelloSignature {
+  Args: { name: string };
+  Element: HTMLHeadingElement;
+}
 
-export default class Hello extends Component<{ Args: Args }> {
+export default class Hello extends Component<HelloSignature> {
   greeting: string = 'hello';
 
   <template>
@@ -76,8 +79,8 @@ test('compiles a .gts source and strips TypeScript syntax', async () => {
   assert.equal(typeof result.code, 'string');
   assert.match(result.code, /@ember\/template-factory/);
   // No leftover TS-only syntax in emitted JS.
-  assert.doesNotMatch(result.code, /interface Args/);
-  assert.doesNotMatch(result.code, /Component<\{ Args: Args \}>/);
+  assert.doesNotMatch(result.code, /interface HelloSignature/);
+  assert.doesNotMatch(result.code, /Component<HelloSignature>/);
   assert.doesNotMatch(result.code, /greeting:\s*string\s*=/);
 });
 

--- a/ember-live-compiler/test/create-owner.test.js
+++ b/ember-live-compiler/test/create-owner.test.js
@@ -1,0 +1,40 @@
+/**
+ * Tests for the minimal Map-backed `createOwner()` exported from the
+ * package root.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { createOwner } from '../dist/index.js';
+
+test('createOwner returns an object with register/lookup', () => {
+  const owner = createOwner();
+  assert.equal(typeof owner.register, 'function');
+  assert.equal(typeof owner.lookup, 'function');
+});
+
+test('lookup returns previously registered instance', () => {
+  const owner = createOwner();
+  const greeting = { hello: 'world' };
+  owner.register('service:greeting', greeting);
+  assert.equal(owner.lookup('service:greeting'), greeting);
+});
+
+test('lookup returns undefined for unknown full names', () => {
+  const owner = createOwner();
+  assert.equal(owner.lookup('service:missing'), undefined);
+});
+
+test('register overwrites a previous value for the same full name', () => {
+  const owner = createOwner();
+  owner.register('service:a', 1);
+  owner.register('service:a', 2);
+  assert.equal(owner.lookup('service:a'), 2);
+});
+
+test('owners are isolated from each other', () => {
+  const a = createOwner();
+  const b = createOwner();
+  a.register('service:x', 'a');
+  assert.equal(b.lookup('service:x'), undefined);
+});

--- a/ember-live-compiler/test/resolver.test.js
+++ b/ember-live-compiler/test/resolver.test.js
@@ -1,0 +1,56 @@
+/**
+ * Tests for the bundler-helper utilities re-exported from
+ * `ember-live-compiler/resolver`. These helpers are pure (no Node-only
+ * APIs, no Babel, no DOM) so they're safe to run in plain Node.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  EMBER_PACKAGE_PREFIXES,
+  EMBROIDER_MACROS_SHIM_SOURCE,
+  EMBROIDER_MACROS_VIRTUAL_ID,
+  isEmberSpecifier,
+} from '../dist/resolver/index.js';
+
+test('EMBER_PACKAGE_PREFIXES lists @ember/ and @glimmer/', () => {
+  assert.deepEqual([...EMBER_PACKAGE_PREFIXES], ['@ember/', '@glimmer/']);
+});
+
+test('isEmberSpecifier matches @ember/* and @glimmer/* specifiers', () => {
+  assert.equal(isEmberSpecifier('@ember/component'), true);
+  assert.equal(isEmberSpecifier('@ember/renderer'), true);
+  assert.equal(isEmberSpecifier('@glimmer/component'), true);
+  assert.equal(isEmberSpecifier('@glimmer/tracking'), true);
+});
+
+test('isEmberSpecifier rejects non-Ember specifiers', () => {
+  assert.equal(isEmberSpecifier('ember-source'), false);
+  assert.equal(isEmberSpecifier('@ember-data/store'), false);
+  assert.equal(isEmberSpecifier('react'), false);
+  assert.equal(isEmberSpecifier(''), false);
+});
+
+test('EMBROIDER_MACROS_VIRTUAL_ID uses the Rollup/Vite \\0 prefix', () => {
+  assert.equal(EMBROIDER_MACROS_VIRTUAL_ID.startsWith('\0'), true);
+});
+
+test('EMBROIDER_MACROS_SHIM_SOURCE exports all consumed macros', () => {
+  const expected = [
+    'isDevelopingApp',
+    'isTesting',
+    'macroCondition',
+    'dependencySatisfies',
+    'getOwnConfig',
+    'getConfig',
+    'importSync',
+    'getGlobalConfig',
+  ];
+  for (const name of expected) {
+    assert.match(
+      EMBROIDER_MACROS_SHIM_SOURCE,
+      new RegExp(`export function ${name}\\b`),
+      `expected shim to export ${name}`,
+    );
+  }
+});

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "format:check": "pnpm -r --if-present format:check",
     "lint": "pnpm -r --if-present lint",
     "lint:fix": "pnpm -r --if-present lint:fix",
-    "preview": "pnpm -C docs preview"
+    "preview": "pnpm -C docs preview",
+    "test": "pnpm -r --if-present test"
   },
   "devDependencies": {
     "prettier": "^3.8.3",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "prettier": "^3.8.3",
     "release-plan": "^0.18.0"
   },
-  "packageManager": "pnpm@11.1.3+sha512.c85357fe17ca12dd23dd7071822666dfd7e3cb76fe214e3370b5ea2fb34f2a231185509b63e717f3cd0acb38dd3f8d82bcd5e8172400ae678b70ea4fbed0896d",
+  "packageManager": "pnpm@11.3.0+sha512.2c403d6594527287672b1f7056343a1f7c3634036a67ffabfcc2b3d7595d843768f8787148d1b57cf7956c90606bbd192857c363af19e96d2d0ec9ec5741d215",
   "engines": {
     "node": ">= 24",
     "pnpm": ">= 10.0.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -106,6 +106,9 @@ importers:
       concurrently:
         specifier: ^9.2.1
         version: 9.2.1
+      ember-source:
+        specifier: ^7.0.0
+        version: 7.0.0(@glimmer/component@2.1.1)
       eslint:
         specifier: ^10.4.0
         version: 10.4.0


### PR DESCRIPTION
Adds the first real test coverage for the engine package, using Node's
built-in node:test runner so we don't take on a test-framework
dependency:

- test/resolver.test.js — pure helper tests (isEmberSpecifier,
  EMBER_PACKAGE_PREFIXES, EMBROIDER_MACROS_VIRTUAL_ID, shim source
  exports).
- test/create-owner.test.js — register/lookup behavior and
  cross-owner isolation for the Map-backed owner.
- test/compile-node.test.js — end-to-end smoke for the Node compile
  pipeline: compile .gjs, .gts (with TS stripping), and
  precompiled-template .js, plus source-map honoring. Lets
  babel-plugin-ember-template-compilation resolve ember-source on its
  own (the documented zero-config path), so this catches regressions
  in that fallback.

Tests run against the built dist/ so they exercise the exact artifact
consumers install. Adds ember-source as devDep for the compile path,
and a test script wired into the root `pnpm test` recursive runner.
CI gets a new Test job that runs after build.