### PR TITLE
ci: smoke-test engine against ember-source LTS and latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,9 +78,12 @@ jobs:
       - run: pnpm install --frozen-lockfile
 
       - name: Pin ember-source@${{ matrix.ember-source }} in the engine package
-        # `pnpm add` rewrites ember-live-compiler/package.json and updates
-        # the lockfile for this job's checkout only — never committed back.
-        run: pnpm --filter ember-live-compiler add -D ember-source@${{ matrix.ember-source }} --no-frozen-lockfile
+        # Rewrite the engine devDep version in-place, then reinstall with
+        # the lockfile unfrozen so pnpm resolves the new ember-source.
+        # Edits are job-scoped and never committed back.
+        run: |
+          npm --prefix ember-live-compiler pkg set devDependencies.ember-source=${{ matrix.ember-source }}
+          pnpm install --no-frozen-lockfile
 
       - name: Build (all workspace packages)
         run: pnpm build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,8 +54,17 @@ jobs:
         run: pnpm build
 
   test:
-    name: Test
+    name: Test (ember-source ${{ matrix.ember-source }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # Smoke-test the engine against the floor of our peer range
+        # (currently the published `lts` tag) AND the published
+        # `latest` tag, so regressions in either direction surface.
+        ember-source:
+          - '6.12.0'
+          - '7.0.0'
     steps:
       - uses: actions/checkout@v6
 
@@ -67,6 +76,11 @@ jobs:
           cache: pnpm
 
       - run: pnpm install --frozen-lockfile
+
+      - name: Pin ember-source@${{ matrix.ember-source }} in the engine package
+        # `pnpm add` rewrites ember-live-compiler/package.json and updates
+        # the lockfile for this job's checkout only — never committed back.
+        run: pnpm --filter ember-live-compiler add -D ember-source@${{ matrix.ember-source }} --no-frozen-lockfile
 
       - name: Build (all workspace packages)
         run: pnpm build


### PR DESCRIPTION
Converts the engine Test job to a matrix that runs the test suite against two ember-source versions:

  - 6.12.0 — the floor of our >= 6.8.0 peer range (npm 'lts' tag)
  - 7.0.0  — the published 'latest'

Each matrix leg overrides ember-live-compiler's devDep via 'pnpm --filter ember-live-compiler add -D ember-source@<ver> --no-frozen-lockfile'. The rewrite is scoped to the job's checkout and never committed back, so reproducibility of root installs is preserved.

fail-fast is off so a regression in one direction doesn't mask the other.