### PR TITLE
feat(ember-live-compiler): browser createBrowserCompiler()

### DIFF
--- a/ember-live-compiler/package.json
+++ b/ember-live-compiler/package.json
@@ -67,8 +67,10 @@
     "decorator-transforms": "^2.3.2"
   },
   "devDependencies": {
+    "@babel/standalone": "^7.29.0",
     "@eslint/js": "^10.0.1",
     "@types/babel__core": "^7.20.5",
+    "@types/babel__standalone": "^7.1.9",
     "@types/node": "^25.9.1",
     "concurrently": "^9.2.1",
     "ember-source": "^7.0.0",
@@ -79,9 +81,13 @@
     "typescript-eslint": "^8.59.4"
   },
   "peerDependencies": {
+    "@babel/standalone": "^7.29.0",
     "ember-source": ">= 6.8.0"
   },
   "peerDependenciesMeta": {
+    "@babel/standalone": {
+      "optional": true
+    },
     "ember-source": {
       "optional": true
     }

--- a/ember-live-compiler/src/runtime/compile.ts
+++ b/ember-live-compiler/src/runtime/compile.ts
@@ -1,0 +1,260 @@
+/**
+ * `ember-live-compiler/runtime` — browser-capable `compile()`.
+ *
+ * Mirrors the Node {@link import('../compile.node.js').createNodeCompiler}
+ * pipeline (content-tag preprocess → Babel transform with
+ * `babel-plugin-ember-template-compilation` + `decorator-transforms` +
+ * optional `@babel/plugin-transform-typescript`) but runs through
+ * `@babel/standalone` so it can execute in a browser worker / main thread.
+ *
+ * Design choices:
+ * - **Lazy imports.** `@babel/standalone` and `content-tag` are only loaded
+ *   the first time {@link BrowserCompiler.compile} runs, so apps that
+ *   only use `render` / `createOwner` don't pay the ~2 MB cost.
+ * - **No `compilerPath`.** Path-based template-compiler resolution is
+ *   Node-only. Callers must pass a preloaded `templateCompiler.compiler`
+ *   module — typically `await import('@ember/template-compiler')` in apps
+ *   running ember-source ≥ 6.8.
+ * - **Bundler picks the right `content-tag`.** Its package exports map a
+ *   `browser` condition to a wasm bundle (`pkg/standalone.js`), so the
+ *   same `import('content-tag')` works in both environments when consumer
+ *   bundlers honor the condition.
+ *
+ * Consumer requirements (browser):
+ * - Add `@babel/standalone` to the app's dependencies (it is declared as an
+ *   **optional** peer here so Node-only / render-only consumers aren't
+ *   forced to install it).
+ * - Resolve `content-tag` with the `browser` export condition (Vite, Rollup,
+ *   webpack 5, esbuild all do this by default).
+ *
+ * Usage:
+ *
+ * ```ts
+ * import { createBrowserCompiler } from 'ember-live-compiler/runtime';
+ *
+ * const compiler = createBrowserCompiler({
+ *   templateCompiler: { compiler: await import('@ember/template-compiler') },
+ * });
+ *
+ * const { code } = await compiler.compile(source, {
+ *   filename: 'inline.gts',
+ *   kind: 'gts',
+ * });
+ * ```
+ */
+
+import type { PluginItem } from '@babel/core';
+
+/** @see {@link import('../compile.node.js').CompileKind} */
+export type CompileKind = 'gjs' | 'gts' | 'precompiled-template';
+
+export interface BrowserCompilerOptions {
+  /**
+   * Pre-loaded Ember template compiler module. Required for any non-trivial
+   * usage — without it, `babel-plugin-ember-template-compilation` will try
+   * to resolve `ember-source` from disk, which won't work in browsers.
+   */
+  templateCompiler?: { compiler?: unknown };
+
+  /**
+   * Extra Babel plugins. Either appended after the built-ins (array form,
+   * matches the Node API), or split around them via `{ before, after }`.
+   */
+  babelPlugins?: PluginItem[] | { before?: PluginItem[]; after?: PluginItem[] };
+
+  /** Extra Babel presets (forwarded as-is). */
+  babelPresets?: PluginItem[];
+}
+
+export interface BrowserCompileFileOptions {
+  filename: string;
+  kind: CompileKind;
+  sourceMaps?: boolean;
+}
+
+export interface BrowserCompileResult {
+  code: string;
+  map?: unknown;
+}
+
+export interface BrowserCompiler {
+  compile(
+    source: string,
+    opts: BrowserCompileFileOptions,
+  ): Promise<BrowserCompileResult | null>;
+}
+
+// Minimal shape of `@babel/standalone`'s `transformAsync` we rely on. We
+// need the async variant because `babel-plugin-ember-template-compilation`
+// runs an async pass.
+interface BabelStandalone {
+  transformAsync(
+    code: string,
+    opts: {
+      filename?: string;
+      babelrc?: boolean;
+      configFile?: boolean;
+      plugins?: PluginItem[];
+      presets?: PluginItem[];
+      parserOpts?: { sourceType?: 'module' | 'script'; plugins?: unknown[] };
+      sourceMaps?: boolean;
+    },
+  ): Promise<{ code?: string | null; map?: unknown } | null>;
+}
+
+type ContentTagModule = typeof import('content-tag');
+
+let babelPromise: Promise<BabelStandalone> | undefined;
+function loadBabel(): Promise<BabelStandalone> {
+  // Literal specifier so bundlers' import analyzers see it. Consumers that
+  // never call `compile()` will not trigger this import.
+  babelPromise ??= import(
+    '@babel/standalone' as string
+  ) as Promise<BabelStandalone>;
+  return babelPromise;
+}
+
+let contentTagPromise: Promise<ContentTagModule> | undefined;
+function loadContentTag(): Promise<ContentTagModule> {
+  contentTagPromise ??= import('content-tag');
+  return contentTagPromise;
+}
+
+let templateCompilationPromise:
+  | Promise<typeof import('babel-plugin-ember-template-compilation')>
+  | undefined;
+function loadTemplateCompilation() {
+  templateCompilationPromise ??=
+    import('babel-plugin-ember-template-compilation');
+  return templateCompilationPromise;
+}
+
+let decoratorTransformsPromise:
+  | Promise<typeof import('decorator-transforms')>
+  | undefined;
+function loadDecoratorTransforms() {
+  decoratorTransformsPromise ??= import('decorator-transforms');
+  return decoratorTransformsPromise;
+}
+
+let tsPluginPromise: Promise<unknown> | undefined;
+function loadTsPlugin(): Promise<unknown> {
+  // `@babel/plugin-transform-typescript` has no published types — we don't
+  // touch any of its API beyond passing it through to Babel as a plugin.
+  tsPluginPromise ??= import(
+    /* @vite-ignore */ '@babel/plugin-transform-typescript' as string
+  );
+  return tsPluginPromise;
+}
+
+const BASE_PARSER_PLUGINS = [
+  'classProperties',
+  'classPrivateProperties',
+  'classPrivateMethods',
+] as const;
+
+/**
+ * Build a stateful browser compiler. Heavy work (deciding plugin order) is
+ * done here so per-file `compile()` calls stay cheap.
+ */
+export function createBrowserCompiler(
+  options: BrowserCompilerOptions = {},
+): BrowserCompiler {
+  const templateCompilationOpts: Record<string, unknown> = options
+    .templateCompiler?.compiler
+    ? { compiler: options.templateCompiler.compiler }
+    : {};
+
+  let userBefore: PluginItem[] = [];
+  let userAfter: PluginItem[] = [];
+  if (Array.isArray(options.babelPlugins)) {
+    userAfter = options.babelPlugins;
+  } else if (options.babelPlugins) {
+    userBefore = options.babelPlugins.before ?? [];
+    userAfter = options.babelPlugins.after ?? [];
+  }
+
+  const presets: PluginItem[] = [...(options.babelPresets ?? [])];
+
+  async function buildPlugins(kind: CompileKind): Promise<PluginItem[]> {
+    const [templateCompilation, decoratorTransforms] = await Promise.all([
+      loadTemplateCompilation(),
+      loadDecoratorTransforms(),
+    ]);
+
+    const tc = (templateCompilation.default ??
+      templateCompilation) as PluginItem;
+    // `decorator-transforms` ships its babel plugin as the default export of
+    // its main entry point.
+    const dt = ((decoratorTransforms as { default?: unknown }).default ??
+      decoratorTransforms) as PluginItem;
+
+    if (kind === 'precompiled-template') {
+      return [[tc, templateCompilationOpts]];
+    }
+
+    return [
+      ...userBefore,
+      [tc, templateCompilationOpts],
+      [dt, { runtime: { import: 'decorator-transforms/runtime' } }],
+      ...userAfter,
+    ];
+  }
+
+  async function compile(
+    source: string,
+    opts: BrowserCompileFileOptions,
+  ): Promise<BrowserCompileResult | null> {
+    const sourceMaps = opts.sourceMaps ?? true;
+    const Babel = await loadBabel();
+    const plugins = await buildPlugins(opts.kind);
+
+    let input = source;
+    if (opts.kind === 'gjs' || opts.kind === 'gts') {
+      const { Preprocessor } = await loadContentTag();
+      const preprocessor = new Preprocessor();
+      const preResult = preprocessor.process(source, {
+        filename: opts.filename,
+      }) as string | { code: string };
+      input = typeof preResult === 'string' ? preResult : preResult.code;
+    }
+
+    const parserPlugins: unknown[] =
+      opts.kind === 'gts'
+        ? [...BASE_PARSER_PLUGINS, 'typescript']
+        : [...BASE_PARSER_PLUGINS];
+
+    let allPlugins: PluginItem[] = plugins;
+    if (opts.kind === 'gts') {
+      const tsPluginMod = await loadTsPlugin();
+      const tsPlugin = ((tsPluginMod as { default?: unknown }).default ??
+        tsPluginMod) as PluginItem;
+      allPlugins = [
+        ...plugins,
+        [
+          tsPlugin,
+          {
+            allExtensions: true,
+            onlyRemoveTypeImports: true,
+            allowDeclareFields: true,
+          },
+        ],
+      ];
+    }
+
+    const result = await Babel.transformAsync(input, {
+      filename: opts.filename,
+      babelrc: false,
+      configFile: false,
+      plugins: allPlugins,
+      presets,
+      parserOpts: { sourceType: 'module', plugins: parserPlugins },
+      sourceMaps,
+    });
+
+    if (!result?.code) return null;
+    return { code: result.code, map: result.map ?? undefined };
+  }
+
+  return { compile };
+}

--- a/ember-live-compiler/src/runtime/index.ts
+++ b/ember-live-compiler/src/runtime/index.ts
@@ -2,16 +2,25 @@
  * `ember-live-compiler/runtime` — browser-safe entry point.
  *
  * Exports:
- * - `createOwner` — Map-backed Ember owner factory (no DOM, no Babel).
- * - `render`     — mount a component module into a DOM element via
- *                  `@ember/renderer` (lazy-imported).
- *
- * Future work: `compile()` (lazy `@babel/standalone` + content-tag wasm) so
- * browsers can also do source → component without a build step.
+ * - `createOwner`            — Map-backed Ember owner factory (no DOM, no Babel).
+ * - `render`                 — mount a component module into a DOM element via
+ *                              `@ember/renderer` (lazy-imported).
+ * - `createBrowserCompiler`  — `compile()` for `.gjs` / `.gts` / precompiled
+ *                              templates that runs through `@babel/standalone`
+ *                              and `content-tag`'s wasm bundle. Both deps are
+ *                              lazy-imported on first compile.
  */
 
 export { createOwner } from '../create-owner.js';
 export { render } from './render.js';
+export { createBrowserCompiler } from './compile.js';
 
 export type { EmberOwner } from '../create-owner.js';
 export type { Mount, RenderOptions } from './render.js';
+export type {
+  BrowserCompiler,
+  BrowserCompilerOptions,
+  BrowserCompileFileOptions,
+  BrowserCompileResult,
+  CompileKind as BrowserCompileKind,
+} from './compile.js';

--- a/ember-live-compiler/test/browser-compile.test.js
+++ b/ember-live-compiler/test/browser-compile.test.js
@@ -1,0 +1,113 @@
+/**
+ * Smoke tests for `createBrowserCompiler()` (the `@babel/standalone`-based
+ * pipeline in `runtime/compile.ts`).
+ *
+ * `@babel/standalone` runs fine in Node, so these tests exercise the same
+ * code path the browser would, just without a real DOM. As with
+ * compile-node.test.js, we don't pre-load a template compiler — the
+ * babel-plugin-ember-template-compilation default resolution finds the
+ * installed `ember-source` and the test catches regressions in that
+ * fallback. Browser consumers must pass `templateCompiler.compiler`.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { createBrowserCompiler } from '../dist/runtime/index.js';
+
+const GJS_SOURCE = `import Component from '@glimmer/component';
+
+export default class Hello extends Component {
+  name = 'world';
+
+  <template>
+    <h1>Hello {{this.name}}</h1>
+  </template>
+}
+`;
+
+const GTS_SOURCE = `import Component from '@glimmer/component';
+
+interface HelloSignature {
+  Args: { name: string };
+  Element: HTMLHeadingElement;
+}
+
+export default class Hello extends Component<HelloSignature> {
+  greeting: string = 'hello';
+
+  <template>
+    <h1>{{this.greeting}} {{@name}}</h1>
+  </template>
+}
+`;
+
+const PRECOMPILED_TEMPLATE_SOURCE = `import { precompileTemplate } from '@ember/template-compilation';
+import templateOnly from '@ember/component/template-only';
+import { setComponentTemplate } from '@ember/component';
+
+const Greeting = templateOnly();
+setComponentTemplate(precompileTemplate('<h1>Hello {{@name}}</h1>', { strictMode: true }), Greeting);
+
+export default Greeting;
+`;
+
+test('createBrowserCompiler compiles a .gjs source via @babel/standalone', async () => {
+  const compiler = createBrowserCompiler();
+  const result = await compiler.compile(GJS_SOURCE, {
+    filename: '/virtual/Hello.gjs',
+    kind: 'gjs',
+  });
+
+  assert.ok(result, 'compile() returned a result');
+  assert.match(result.code, /@ember\/template-factory/);
+  assert.doesNotMatch(result.code, /<template>/);
+});
+
+test('createBrowserCompiler compiles a .gts source and strips TS syntax', async () => {
+  const compiler = createBrowserCompiler();
+  const result = await compiler.compile(GTS_SOURCE, {
+    filename: '/virtual/Hello.gts',
+    kind: 'gts',
+  });
+
+  assert.ok(result);
+  assert.match(result.code, /@ember\/template-factory/);
+  assert.doesNotMatch(result.code, /interface HelloSignature/);
+  assert.doesNotMatch(result.code, /Component<HelloSignature>/);
+  assert.doesNotMatch(result.code, /greeting: string =/);
+});
+
+test('createBrowserCompiler handles precompiled-template kind', async () => {
+  const compiler = createBrowserCompiler();
+  const result = await compiler.compile(PRECOMPILED_TEMPLATE_SOURCE, {
+    filename: '/virtual/greeting.js',
+    kind: 'precompiled-template',
+  });
+
+  assert.ok(result);
+  assert.match(result.code, /@ember\/template-factory/);
+  assert.doesNotMatch(result.code, /precompileTemplate\(/);
+});
+
+test('createBrowserCompiler honors sourceMaps: false', async () => {
+  const compiler = createBrowserCompiler();
+  const result = await compiler.compile(GJS_SOURCE, {
+    filename: '/virtual/Hello.gjs',
+    kind: 'gjs',
+    sourceMaps: false,
+  });
+
+  assert.ok(result);
+  assert.equal(result.map, undefined);
+});
+
+test('createBrowserCompiler emits a source map by default', async () => {
+  const compiler = createBrowserCompiler();
+  const result = await compiler.compile(GJS_SOURCE, {
+    filename: '/virtual/Hello.gjs',
+    kind: 'gjs',
+  });
+
+  assert.ok(result);
+  assert.ok(result.map, 'sourceMaps default is true');
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -94,12 +94,18 @@ importers:
         specifier: ^2.3.2
         version: 2.3.2(@babel/core@7.29.0)
     devDependencies:
+      '@babel/standalone':
+        specifier: ^7.29.0
+        version: 7.29.4
       '@eslint/js':
         specifier: ^10.0.1
         version: 10.0.1(eslint@10.4.0)
       '@types/babel__core':
         specifier: ^7.20.5
         version: 7.20.5
+      '@types/babel__standalone':
+        specifier: ^7.1.9
+        version: 7.1.9
       '@types/node':
         specifier: ^25.9.1
         version: 25.9.1
@@ -778,6 +784,10 @@ packages:
 
   '@babel/runtime@7.12.18':
     resolution: {integrity: sha512-BogPQ7ciE6SYAUPtlm9tWbgI9+2AgqSam6QivMgXgAT+fKbgppaj4ZX15MHeLC1PVF5sNk70huBu20XxWOs8Cg==}
+
+  '@babel/standalone@7.29.4':
+    resolution: {integrity: sha512-QuPlodN3HBcX/HcKRz0fkpr8hmqhY+OKwX89h/vBVKuSat5ohvZw4XGNwfF1LtwScmp5ILBAO7puXwJDcMEtJQ==}
+    engines: {node: '>=6.9.0'}
 
   '@babel/template@7.28.6':
     resolution: {integrity: sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==}
@@ -1638,6 +1648,9 @@ packages:
 
   '@types/babel__generator@7.27.0':
     resolution: {integrity: sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==}
+
+  '@types/babel__standalone@7.1.9':
+    resolution: {integrity: sha512-IcCNPLqpevUD7UpV8QB0uwQPOyoOKACFf0YtYWRHcmxcakaje4Q7dbG2+jMqxw/I8Zk0NHvEps66WwS7z/UaaA==}
 
   '@types/babel__template@7.4.4':
     resolution: {integrity: sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==}
@@ -5056,6 +5069,8 @@ snapshots:
     dependencies:
       regenerator-runtime: 0.13.11
 
+  '@babel/standalone@7.29.4': {}
+
   '@babel/template@7.28.6':
     dependencies:
       '@babel/code-frame': 7.29.0
@@ -5771,6 +5786,15 @@ snapshots:
   '@types/babel__generator@7.27.0':
     dependencies:
       '@babel/types': 7.29.0
+
+  '@types/babel__standalone@7.1.9':
+    dependencies:
+      '@babel/parser': 7.29.3
+      '@babel/types': 7.29.0
+      '@types/babel__core': 7.20.5
+      '@types/babel__generator': 7.27.0
+      '@types/babel__template': 7.4.4
+      '@types/babel__traverse': 7.28.0
 
   '@types/babel__template@7.4.4':
     dependencies:


### PR DESCRIPTION
Adds a new runtime export `createBrowserCompiler` that mirrors the Node `createNodeCompiler` pipeline but runs through `@babel/standalone` + `content-tag` (browser-condition wasm bundle), enabling .gjs/.gts compilation in a browser worker / main thread without a build step.

## Why
Unblocks the "Phase B" runtime story in the master plan: docs/preview tools (kolay, docusaurus, storybook, future VitePress live-editor) can now share one engine for both build-time and runtime compilation.

## What's in
- `src/runtime/compile.ts` — new `BrowserCompiler` with lazy imports of `@babel/standalone`, `content-tag`, `babel-plugin-ember-template-compilation`, `decorator-transforms`, and `@babel/plugin-transform-typescript` so apps that only use `render` / `createOwner` pay no extra cost.
- `src/runtime/index.ts` — re-export.
- `package.json` — `@babel/standalone` declared as **optional peer**; added as devDep so the local test suite can exercise the pipeline.
- `test/browser-compile.test.js` — 5 smoke tests covering `.gjs`, `.gts`, precompiled-template, `sourceMaps: false`, and default source maps.

## API
```ts
import { createBrowserCompiler } from 'ember-live-compiler/runtime';

const compiler = createBrowserCompiler({
  templateCompiler: { compiler: await import('@ember/template-compiler') },
});

const { code } = await compiler.compile(source, {
  filename: 'inline.gts',
  kind: 'gts',
});
```

## Consumer requirements
- Browser apps must add `@babel/standalone` to their deps (optional peer here so render-only consumers aren't forced to install it).
- Bundler must honor `content-tag`'s `browser` export condition (Vite / Rollup / webpack 5 / esbuild all do by default).

## Tests
20/20 passing (15 existing + 5 new).