### PR TITLE
docs: showcase new browser createBrowserCompiler() API

### DIFF
--- a/docs/guide/how-it-works.md
+++ b/docs/guide/how-it-works.md
@@ -100,3 +100,15 @@ Ember's ESM packages call functions like `isDevelopingApp()` and `macroCondition
 ### Why `content-tag` + Babel (two stages)?
 
 Ember's `<template>` tag syntax is not valid JavaScript — it needs a custom preprocessor (`content-tag`) to convert it first. Then Babel handles template compilation to wire format and decorator transforms. This two-stage approach matches how the Ember ecosystem processes `.gjs`/`.gts` files.
+
+## Beyond VitePress: the engine
+
+The build-time pipeline and the browser-side renderer live in [`ember-live-compiler`](https://www.npmjs.com/package/ember-live-compiler), a separate bundler-agnostic package that `vite-plugin-ember` depends on. Other doc tools (Docusaurus, Storybook, Backstage TechDocs, kolay) can share the same engine instead of reimplementing it.
+
+Three subpath exports cover the typical needs:
+
+- **`ember-live-compiler`** — Node-only `createNodeCompiler()`. Wrap it in any bundler plugin to get `.gjs` / `.gts` support.
+- **`ember-live-compiler/runtime`** — Browser-safe `render()`, `createOwner()`, and **`createBrowserCompiler()`** for fully in-browser source → component (lazy `@babel/standalone` + `content-tag` wasm). Useful for live REPLs and playgrounds where there is no build step.
+- **`ember-live-compiler/resolver`** — Pure `@ember/*` / `@glimmer/*` helpers with no I/O, safe to import anywhere.
+
+See the engine [README](https://www.npmjs.com/package/ember-live-compiler) for the full API.

--- a/ember-live-compiler/README.md
+++ b/ember-live-compiler/README.md
@@ -33,11 +33,11 @@ call `render()`, since it dynamically imports `@ember/renderer`.
 
 ## Subpath exports
 
-| Import                         | Environment   | Purpose                                                        |
-| ------------------------------ | ------------- | -------------------------------------------------------------- |
-| `ember-live-compiler`          | Node          | Build-time `createNodeCompiler()` — Babel + content-tag.       |
-| `ember-live-compiler/runtime`  | Browser       | `render()` + `createOwner()` for mounting compiled components. |
-| `ember-live-compiler/resolver` | Node, Browser | Pure helpers for resolving `@ember/*` / `@glimmer/*`.          |
+| Import                         | Environment   | Purpose                                                                                  |
+| ------------------------------ | ------------- | ---------------------------------------------------------------------------------------- |
+| `ember-live-compiler`          | Node          | Build-time `createNodeCompiler()` — Babel + content-tag.                                 |
+| `ember-live-compiler/runtime`  | Browser       | `createBrowserCompiler()` + `render()` + `createOwner()` — compile and mount in-browser. |
+| `ember-live-compiler/resolver` | Node, Browser | Pure helpers for resolving `@ember/*` / `@glimmer/*`.                                    |
 
 ## Node — build-time compile
 
@@ -84,6 +84,44 @@ call it don't pay the import cost. The host bundler must be able to resolve
 `ssr.noExternal` rule already handle this; equivalent wiring is needed for
 other bundlers.
 
+## Browser — compile
+
+```ts
+import { createBrowserCompiler } from 'ember-live-compiler/runtime';
+
+const compiler = createBrowserCompiler({
+  // Required in real browsers — the babel plugin can't resolve ember-source
+  // from disk. Pass a pre-loaded compiler module.
+  templateCompiler: { compiler: await import('@ember/template-compiler') },
+});
+
+const { code, map } = await compiler.compile(source, {
+  filename: 'inline.gts',
+  kind: 'gts', // 'gjs' | 'gts' | 'precompiled-template'
+  sourceMaps: true,
+});
+
+// Feed `code` into a blob-URL / dynamic import / `Function(...)` and then
+// `render()` the resulting module.
+```
+
+Mirrors the Node pipeline (content-tag → Babel with
+`babel-plugin-ember-template-compilation` + `decorator-transforms` + optional
+`@babel/plugin-transform-typescript`) but runs through `@babel/standalone` so
+it can execute in a worker or on the main thread. Every dependency
+(`@babel/standalone`, `content-tag`, the babel plugins, the TS transform) is
+**lazy-imported on first compile**, so apps that only use `render` /
+`createOwner` pay no extra cost.
+
+Consumer checklist:
+
+- Add `@babel/standalone` to your app (declared as an **optional** peer here).
+- Ensure your bundler honors `content-tag`'s `browser` export condition (Vite,
+  Rollup, webpack 5, esbuild all do by default) — that picks the wasm bundle
+  instead of the Node native binding.
+- Pre-load `@ember/template-compiler` from your host app and pass it via
+  `templateCompiler.compiler`. (`compilerPath` is Node-only.)
+
 ## Resolver helpers
 
 For bundler authors who need to wire up `@ember/*` resolution themselves:
@@ -101,12 +139,11 @@ Pure, bundler-free. No I/O, no Babel, safe to import from anywhere.
 
 ## Status
 
-`0.1.x` — public but pre-stable. The Node compile pipeline and runtime
-`render()` are exercised in production by `vite-plugin-ember`'s VitePress
-docs. Planned for upcoming minors:
+`0.2.x` — public but pre-stable. The Node compile pipeline, browser
+`createBrowserCompiler()`, and runtime `render()` are all exercised by the
+20-test suite (node `--test`) running against ember-source LTS + latest in
+CI. Planned for upcoming minors:
 
-- `compile()` in `runtime` (lazy `@babel/standalone` + content-tag wasm) for
-  fully in-browser source → component.
 - Stable 1.0 once at least one additional bundler integration ships against
   the engine.
 


### PR DESCRIPTION
Documents the runtime compile API that landed in #86.

- **ember-live-compiler/README.md**: new "Browser — compile" section with usage example and consumer checklist; lists `createBrowserCompiler` in the subpath-exports table; drops the "planned" bullet from Status (it now ships).
- **docs/guide/how-it-works.md**: new "Beyond VitePress: the engine" section that mentions all three subpath exports and links to the engine README, so VitePress readers extending the plugin discover the runtime compile capability.