### PR TITLE
fix(vite-plugin-ember): exclude content-tag from optimizeDeps

### DIFF
--- a/vite-plugin-ember/src/index.ts
+++ b/vite-plugin-ember/src/index.ts
@@ -252,6 +252,13 @@ export default function vitePluginEmber(
      * native ESM, is enormous, and pre-bundling it would just duplicate
      * everything our `resolveId` already serves.
      *
+     * Likewise, `content-tag` (used by `ember-live-compiler`'s runtime
+     * compile pipeline) ships a wasm bundle whose browser entry uses
+     * top-level await. Vite's default esbuild dep-optimizer targets
+     * safari14, which rejects TLA, so excluding it lets Vite serve the
+     * package as-is to the (TLA-capable) dev browser instead of trying
+     * to pre-bundle it.
+     *
      * SSR has the mirror-image problem. By default Vite externalizes every
      * npm dep for SSR, handing import resolution off to Node's native ESM
      * loader. That loader has no plugin pipeline, so when something in the
@@ -265,7 +272,7 @@ export default function vitePluginEmber(
     config() {
       return {
         optimizeDeps: {
-          exclude: ['ember-source'],
+          exclude: ['ember-source', 'content-tag'],
           esbuildOptions: {
             plugins: [
               {


### PR DESCRIPTION
`content-tag` (used by `ember-live-compiler`'s runtime compile pipeline) ships a wasm bundle whose browser entry uses top-level await. Vite's default esbuild dep-optimizer targets safari14, which rejects TLA, so every Vite consumer of this plugin currently fails to start their dev server with:

    ✘ Top-level await is not available in the configured target
      environment ("chrome87", "edge88", "es2020", "firefox78",
      "safari14" + 2 overrides)
      node_modules/.pnpm/content-tag@4.2.0/node_modules/content-tag/pkg/standalone.js:4:0

Excluding `content-tag` from `optimizeDeps` lets Vite serve the package as-is to the (TLA-capable) dev browser instead of trying to pre-bundle it through esbuild.